### PR TITLE
fix(ds-workspace): invalid schema for the workspace identity

### DIFF
--- a/.changes/unreleased/fixed-20240925-204940.yaml
+++ b/.changes/unreleased/fixed-20240925-204940.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: |
+  The `fabric_workspace` data-source had invalid schema for the workspace identity.
+  The schema has been changed from `enabled` (bool) to `type` (string).
+time: 2024-09-25T20:49:40.662186-07:00
+custom:
+  Issue: "15"

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -67,5 +67,5 @@ Optional:
 Read-Only:
 
 - `application_id` (String) The application ID.
-- `enabled` (Boolean) The workspace identity status.
 - `service_principal_id` (String) The service principal ID.
+- `type` (String) The workspace identity type. Possible values: `SystemAssigned`.

--- a/internal/services/workspace/data_workspace.go
+++ b/internal/services/workspace/data_workspace.go
@@ -85,8 +85,8 @@ func (d *dataSourceWorkspace) Schema(ctx context.Context, _ datasource.SchemaReq
 				Computed:            true,
 				CustomType:          supertypes.NewSingleNestedObjectTypeOf[workspaceIdentityModel](ctx),
 				Attributes: map[string]schema.Attribute{
-					"enabled": schema.BoolAttribute{
-						MarkdownDescription: "The workspace identity status.",
+					"type": schema.StringAttribute{
+						MarkdownDescription: "The workspace identity type. Possible values: " + utils.ConvertStringSlicesToString(workspaceIdentityTypes, true, true) + ".",
 						Computed:            true,
 					},
 					"application_id": schema.StringAttribute{

--- a/internal/testhelp/wellknown.go
+++ b/internal/testhelp/wellknown.go
@@ -390,7 +390,7 @@ func CreateWellKnownResources() { //nolint:maintidx
 	panicOnError(err)
 	log.Printf("Created Entra Group (DisplayName: %s, ObjectID: %s)\n", *group.DisplayName, *group.Id)
 
-	values.Group.ID = sp.Id
+	values.Group.ID = group.Id
 	values.Group.Type = to.Ptr("Group")
 
 	// write the values to the file, pretty printed


### PR DESCRIPTION
# 📥 Pull Request

close #15

## ❓ What are you trying to address

This pull request addresses a schema issue in the `fabric_workspace` data-source and includes related documentation and code updates. The most important changes include fixing the schema, updating the documentation, and modifying the relevant code to reflect the schema change.

## ✨ Description of new changes

Documentation Update:

* [`docs/data-sources/workspace.md`](diffhunk://#diff-7cd9d7c89e4d61074ba868cdb987ff36a2cd7b06c205e0926cb33a0e37a4c586L70-R71): Updated the `enabled` attribute to `type` in the workspace identity documentation.

Bug Fix:

* [`internal/services/workspace/data_workspace.go`](diffhunk://#diff-56f9c23c9a9645da1fae3a5fb8a2019a63fe3ccc69d44b973c1cc4e733df273bL88-R89): Modified the schema attribute from `enabled` (bool) to `type` (string) in the `Schema` function.

Bug Fix:

* [`internal/testhelp/wellknown.go`](diffhunk://#diff-433c3c086ae764bf7e657e3522ab3449c7b901b01acbe63b857b2d7779e480bfL393-R393): Fixed a bug where `values.Group.ID` was incorrectly set to `sp.Id` instead of `group.Id`.