### PR TITLE
feat(build): add additional binaries

### DIFF
--- a/.changes/unreleased/added-20240930-235244.yaml
+++ b/.changes/unreleased/added-20240930-235244.yaml
@@ -5,4 +5,4 @@ body: |
   - arch: 386
 time: 2024-09-30T23:52:44.4012609-07:00
 custom:
-  Issue: "111"
+  Issue: "22"

--- a/.changes/unreleased/added-20240930-235244.yaml
+++ b/.changes/unreleased/added-20240930-235244.yaml
@@ -1,0 +1,8 @@
+kind: added
+body: |
+  Additional binaries to the build artifacts
+  - os: freebsd
+  - arch: 386
+time: 2024-09-30T23:52:44.4012609-07:00
+custom:
+  Issue: "111"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,16 +23,18 @@ builds:
     ldflags:
       - "-s -w -X {{ .ModulePath }}/main.version={{ .Version }}"
     goos:
+      - freebsd
       - windows
       - linux
       - darwin
     goarch:
       - amd64
+      - "386"
       - arm
       - arm64
     ignore:
       - goos: darwin
-        goarch: arm
+        goarch: "386"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 checksum:


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes changes to add support for additional binaries in the build artifacts. The most important changes involve updates to the build configuration to include FreeBSD and 386 architectures.

## ✨ Description of new changes

Build configuration updates:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R26-R37): Updated `goos` to include FreeBSD and `goarch` to include 386. Also modified the `ignore` section to exclude 386 architecture for Darwin.
