### PR TITLE
docs: fix broken links in troubleshooting guide

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,7 +115,7 @@ tasks:
   lint:links:
     desc: Run link checkers
     cmds:
-      - lychee --config ./.github/linters/.lychee.toml .
+      - lychee --config ./.github/linters/.lychee.toml --format markdown .
 
   tools:
     desc: Install required tools

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -35,7 +35,7 @@ For more information about Terraform logging, see [Debugging Terraform](https://
 
 - Check if your SPN, MSI or User that is used for Provider authentication is added to Fabric `Capacity administrators`.
 - Check if your Fabric Capacity is not in the `paused` state.
-- Majority of Fabric Items require to have Fabric Capacity assigned to the workspace. If you manage Workspace using [`fabric_workspace` resource](../resources/workspace), ensure that you have assigned Fabric Capacity to the Workspace.
+- Majority of Fabric Items require to have Fabric Capacity assigned to the workspace. If you manage Workspace using [`fabric_workspace` resource](../resources/workspace.md), ensure that you have assigned Fabric Capacity to the Workspace.
 
 ### I am getting error `Unable to find Capacity...`
 
@@ -44,7 +44,7 @@ For more information about Terraform logging, see [Debugging Terraform](https://
 
 ### I am getting error `Failed to create workspace identity`
 
-- If you manage Workspace using [`fabric_workspace` resource](../resources/workspace), ensure that you have assigned Fabric Capacity to the Workspace.
+- If you manage Workspace using [`fabric_workspace` resource](../resources/workspace.md), ensure that you have assigned Fabric Capacity to the Workspace.
 - Check if your Fabric Capacity assigned to the Workspace is not in the `paused` state.
 
 ### I am getting error `Workspace name already exists`

--- a/templates/guides/troubleshooting.md.tmpl
+++ b/templates/guides/troubleshooting.md.tmpl
@@ -35,7 +35,7 @@ For more information about Terraform logging, see [Debugging Terraform](https://
 
 - Check if your SPN, MSI or User that is used for Provider authentication is added to Fabric `Capacity administrators`.
 - Check if your Fabric Capacity is not in the `paused` state.
-- Majority of Fabric Items require to have Fabric Capacity assigned to the workspace. If you manage Workspace using [`fabric_workspace` resource](../resources/workspace), ensure that you have assigned Fabric Capacity to the Workspace.
+- Majority of Fabric Items require to have Fabric Capacity assigned to the workspace. If you manage Workspace using [`fabric_workspace` resource](../resources/workspace.md), ensure that you have assigned Fabric Capacity to the Workspace.
 
 ### I am getting error `Unable to find Capacity...`
 
@@ -44,7 +44,7 @@ For more information about Terraform logging, see [Debugging Terraform](https://
 
 ### I am getting error `Failed to create workspace identity`
 
-- If you manage Workspace using [`fabric_workspace` resource](../resources/workspace), ensure that you have assigned Fabric Capacity to the Workspace.
+- If you manage Workspace using [`fabric_workspace` resource](../resources/workspace.md), ensure that you have assigned Fabric Capacity to the Workspace.
 - Check if your Fabric Capacity assigned to the Workspace is not in the `paused` state.
 
 ### I am getting error `Workspace name already exists`


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the documentation to correct file references for the `fabric_workspace` resource. The changes ensure that the links point to the correct `.md` file.

## ✨ Description of new changes

Documentation updates:

* [`docs/guides/troubleshooting.md`](diffhunk://#diff-05fa5078290d9319b91e520b8d624cd018e97d963be0d0e1cd22ca7e37e899e9L38-R38): Updated the reference to `fabric_workspace` resource to point to `workspace.md` instead of `workspace`. [[1]](diffhunk://#diff-05fa5078290d9319b91e520b8d624cd018e97d963be0d0e1cd22ca7e37e899e9L38-R38) [[2]](diffhunk://#diff-05fa5078290d9319b91e520b8d624cd018e97d963be0d0e1cd22ca7e37e899e9L47-R47)
* [`templates/guides/troubleshooting.md.tmpl`](diffhunk://#diff-05fa5078290d9319b91e520b8d624cd018e97d963be0d0e1cd22ca7e37e899e9L38-R38): Updated the reference to `fabric_workspace` resource to point to `workspace.md` instead of `workspace`. [[1]](diffhunk://#diff-05fa5078290d9319b91e520b8d624cd018e97d963be0d0e1cd22ca7e37e899e9L38-R38) [[2]](diffhunk://#diff-05fa5078290d9319b91e520b8d624cd018e97d963be0d0e1cd22ca7e37e899e9L47-R47)
