### PR TITLE
build(deps): bump go and terraform

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     },
     // "ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.23.1"
+      "version": "1.23.2"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
@@ -36,7 +36,7 @@
     // "ghcr.io/guiyomh/features/gomarkdoc:0": {},
     // "ghcr.io/guiyomh/features/gotestsum:0": {},
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.9.6",
+      "version": "1.9.7",
       "installSentinel": true,
       "installTFsec": true,
       "installTerraformDocs": true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/terraform-provider-fabric
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the `.devcontainer/devcontainer.json` and `go.mod` files to upgrade the versions of Go and Terraform used in the project.

## ✨ Description of new changes

Version upgrades:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L18-R18): Updated the Go version from `1.23.1` to `1.23.2`.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L39-R39): Updated the Terraform version from `1.9.6` to `1.9.7`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.1` to `1.23.2`.
