### PR TITLE
fix(rs-workspace): add intermediary state checkpoints

### DIFF
--- a/.changes/unreleased/fixed-20241003-000007.yaml
+++ b/.changes/unreleased/fixed-20241003-000007.yaml
@@ -1,5 +1,5 @@
 kind: fixed
-body: Add intermediary state save checkpoint for `fabric_workspace` Resource
+body: Add intermediary state checkpoints for `fabric_workspace` Resource
 time: 2024-10-03T00:00:07.8739957-07:00
 custom:
-    Issue: "111"
+  Issue: "29"

--- a/.changes/unreleased/fixed-20241003-000007.yaml
+++ b/.changes/unreleased/fixed-20241003-000007.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Add intermediary state save checkpoint for `fabric_workspace` Resource
+time: 2024-10-03T00:00:07.8739957-07:00
+custom:
+    Issue: "111"


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request introduces a checkpoint mechanism for saving intermediary states in the `fabric_workspace` resource, which helps in improving the reliability of state management during create and update operations.

## ✨ Description of new changes

* `internal/services/workspace/resource_workspace.go`:
  * `func (r *resourceWorkspace) Create(ctx context.Context, req resource.CreateReque)`: Added intermediary state save checkpoints after creating the resource and before setting the final state. 
  * `func (r *resourceWorkspace) Update(ctx context.Context, req resource.UpdateReque)`: Introduced an `intermediary` variable to hold the state at different stages of the update process, and added checkpoints to save this intermediary state. 


