### PR TITLE
feat(workspace-capacity): add additional properties for region and 1lake endpoints

### DIFF
--- a/.changes/unreleased/added-20241011-163624.yaml
+++ b/.changes/unreleased/added-20241011-163624.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: 'New read-only properties in the `fabric_workspace` Resource/Data-Source: `capacity_region`, `onelake_endpoints`'
+time: 2024-10-11T16:36:24.8279227+02:00
+custom:
+    Issue: "46"

--- a/.changes/unreleased/changed-20241011-163751.yaml
+++ b/.changes/unreleased/changed-20241011-163751.yaml
@@ -1,0 +1,5 @@
+kind: changed
+body: Updated docs for possible values for `state` and `region` in the `fabric_capacity` Data-Source.
+time: 2024-10-11T16:37:51.3606012+02:00
+custom:
+    Issue: "46"

--- a/docs/data-sources/capacities.md
+++ b/docs/data-sources/capacities.md
@@ -49,6 +49,6 @@ Read-Only:
 
 - `display_name` (String) The Capacity display name.
 - `id` (String) The Capacity ID.
-- `region` (String) The Azure region where the Capacity has been provisioned.
+- `region` (String) The Azure region where the Capacity has been provisioned. Possible values: `Australia East`, `Australia Southeast`, `Brazil South`, `Brazil Southeast`, `Canada Central`, `Canada East`, `Central India`, `Central US`, `Central US EUAP`, `China East`, `China East 2`, `China East 3`, `China North`, `China North 2`, `China North 3`, `East Asia`, `East US`, `East US 2`, `France Central`, `France South`, `Germany Central`, `Germany North`, `Germany Northeast`, `Germany West Central`, `Israel Central`, `Italy North`, `Japan East`, `Japan West`, `Korea Central`, `Korea South`, `Mexico Central`, `North Central US`, `North Europe`, `Norway East`, `Norway West`, `Poland Central`, `Qatar Central`, `South Africa North`, `South Africa West`, `South Central US`, `South India`, `Southeast Asia`, `Spain Central`, `Sweden Central`, `Switzerland North`, `Switzerland West`, `UAE Central`, `UAE North`, `UK South`, `UK West`, `West Central US`, `West Europe`, `West India`, `West US`, `West US 2`, `West US 3`
 - `sku` (String) The Capacity SKU.
-- `state` (String) The Capacity state.
+- `state` (String) The Capacity state. Possible values: `Active`, `Inactive`

--- a/docs/data-sources/capacity.md
+++ b/docs/data-sources/capacity.md
@@ -46,9 +46,9 @@ data "fabric_capacity" "example_by_name" {
 
 ### Read-Only
 
-- `region` (String) The Azure region where the Capacity has been provisioned.
+- `region` (String) The Azure region where the Capacity has been provisioned. Possible values: `Australia East`, `Australia Southeast`, `Brazil South`, `Brazil Southeast`, `Canada Central`, `Canada East`, `Central India`, `Central US`, `Central US EUAP`, `China East`, `China East 2`, `China East 3`, `China North`, `China North 2`, `China North 3`, `East Asia`, `East US`, `East US 2`, `France Central`, `France South`, `Germany Central`, `Germany North`, `Germany Northeast`, `Germany West Central`, `Israel Central`, `Italy North`, `Japan East`, `Japan West`, `Korea Central`, `Korea South`, `Mexico Central`, `North Central US`, `North Europe`, `Norway East`, `Norway West`, `Poland Central`, `Qatar Central`, `South Africa North`, `South Africa West`, `South Central US`, `South India`, `Southeast Asia`, `Spain Central`, `Sweden Central`, `Switzerland North`, `Switzerland West`, `UAE Central`, `UAE North`, `UK South`, `UK West`, `West Central US`, `West Europe`, `West India`, `West US`, `West US 2`, `West US 3`
 - `sku` (String) The Capacity SKU.
-- `state` (String) The Capacity state.
+- `state` (String) The Capacity state. Possible values: `Active`, `Inactive`
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -46,10 +46,12 @@ data "fabric_workspace" "example_by_name" {
 
 ### Read-Only
 
-- `capacity_assignment_progress` (String) A Workspace assignment to capacity progress status.
+- `capacity_assignment_progress` (String) A Workspace assignment to capacity progress status. Possible values: `Completed`, `Failed`, `InProgress`
 - `capacity_id` (String) The ID of the Capacity the Workspace is assigned to.
+- `capacity_region` (String) The region of the capacity associated with this workspace. Possible values: `Australia East`, `Australia Southeast`, `Brazil South`, `Brazil Southeast`, `Canada Central`, `Canada East`, `Central India`, `Central US`, `Central US EUAP`, `China East`, `China East 2`, `China East 3`, `China North`, `China North 2`, `China North 3`, `East Asia`, `East US`, `East US 2`, `France Central`, `France South`, `Germany Central`, `Germany North`, `Germany Northeast`, `Germany West Central`, `Israel Central`, `Italy North`, `Japan East`, `Japan West`, `Korea Central`, `Korea South`, `Mexico Central`, `North Central US`, `North Europe`, `Norway East`, `Norway West`, `Poland Central`, `Qatar Central`, `South Africa North`, `South Africa West`, `South Central US`, `South India`, `Southeast Asia`, `Spain Central`, `Sweden Central`, `Switzerland North`, `Switzerland West`, `UAE Central`, `UAE North`, `UK South`, `UK West`, `West Central US`, `West Europe`, `West India`, `West US`, `West US 2`, `West US 3`
 - `description` (String) The Workspace description.
 - `identity` (Attributes) A workspace identity object. (see [below for nested schema](#nestedatt--identity))
+- `onelake_endpoints` (Attributes) The OneLake API endpoints associated with this workspace. (see [below for nested schema](#nestedatt--onelake_endpoints))
 - `type` (String) The Workspace type.
 
 <a id="nestedatt--timeouts"></a>
@@ -69,3 +71,12 @@ Read-Only:
 - `application_id` (String) The application ID.
 - `service_principal_id` (String) The service principal ID.
 - `type` (String) The workspace identity type. Possible values: `SystemAssigned`.
+
+<a id="nestedatt--onelake_endpoints"></a>
+
+### Nested Schema for `onelake_endpoints`
+
+Read-Only:
+
+- `blob_endpoint` (String) The OneLake API endpoint available for Blob API operations.
+- `dfs_endpoint` (String) The OneLake API endpoint available for Distributed File System (DFS) or ADLSgen2 filesystem API operations.

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -59,8 +59,10 @@ See [Workspace Identity](https://learn.microsoft.com/fabric/security/workspace-i
 
 ### Read-Only
 
-- `capacity_assignment_progress` (String) A Workspace assignment to capacity progress status.
+- `capacity_assignment_progress` (String) A Workspace assignment to capacity progress status. Possible values: `Completed`, `Failed`, `InProgress`
+- `capacity_region` (String) The region of the capacity associated with this workspace. Possible values: `Australia East`, `Australia Southeast`, `Brazil South`, `Brazil Southeast`, `Canada Central`, `Canada East`, `Central India`, `Central US`, `Central US EUAP`, `China East`, `China East 2`, `China East 3`, `China North`, `China North 2`, `China North 3`, `East Asia`, `East US`, `East US 2`, `France Central`, `France South`, `Germany Central`, `Germany North`, `Germany Northeast`, `Germany West Central`, `Israel Central`, `Italy North`, `Japan East`, `Japan West`, `Korea Central`, `Korea South`, `Mexico Central`, `North Central US`, `North Europe`, `Norway East`, `Norway West`, `Poland Central`, `Qatar Central`, `South Africa North`, `South Africa West`, `South Central US`, `South India`, `Southeast Asia`, `Spain Central`, `Sweden Central`, `Switzerland North`, `Switzerland West`, `UAE Central`, `UAE North`, `UK South`, `UK West`, `West Central US`, `West Europe`, `West India`, `West US`, `West US 2`, `West US 3`
 - `id` (String) The Workspace ID.
+- `onelake_endpoints` (Attributes) The OneLake API endpoints associated with this workspace. (see [below for nested schema](#nestedatt--onelake_endpoints))
 - `type` (String) The Workspace type.
 
 <a id="nestedatt--identity"></a>
@@ -86,6 +88,15 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+<a id="nestedatt--onelake_endpoints"></a>
+
+### Nested Schema for `onelake_endpoints`
+
+Read-Only:
+
+- `blob_endpoint` (String) The OneLake API endpoint available for Blob API operations.
+- `dfs_endpoint` (String) The OneLake API endpoint available for Distributed File System (DFS) or ADLSgen2 filesystem API operations.
 
 ## Import
 

--- a/internal/services/capacity/data_capacities.go
+++ b/internal/services/capacity/data_capacities.go
@@ -58,7 +58,7 @@ func (d *dataSourceCapacities) Schema(ctx context.Context, _ datasource.SchemaRe
 							Computed:            true,
 						},
 						"region": schema.StringAttribute{
-							MarkdownDescription: fmt.Sprintf("The Azure region where the %s has been provisioned.", ItemName),
+							MarkdownDescription: "The Azure region where the " + ItemName + " has been provisioned. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityRegionValues(), true, true),
 							Computed:            true,
 						},
 						"sku": schema.StringAttribute{
@@ -66,7 +66,7 @@ func (d *dataSourceCapacities) Schema(ctx context.Context, _ datasource.SchemaRe
 							Computed:            true,
 						},
 						"state": schema.StringAttribute{
-							MarkdownDescription: fmt.Sprintf("The %s state.", ItemName),
+							MarkdownDescription: "The " + ItemName + " state. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityStateValues(), true, true),
 							Computed:            true,
 						},
 					},

--- a/internal/services/capacity/data_capacity.go
+++ b/internal/services/capacity/data_capacity.go
@@ -58,7 +58,7 @@ func (d *dataSourceCapacity) Schema(ctx context.Context, _ datasource.SchemaRequ
 				Computed:            true,
 			},
 			"region": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The Azure region where the %s has been provisioned.", ItemName),
+				MarkdownDescription: "The Azure region where the " + ItemName + " has been provisioned. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityRegionValues(), true, true),
 				Computed:            true,
 			},
 			"sku": schema.StringAttribute{
@@ -66,7 +66,7 @@ func (d *dataSourceCapacity) Schema(ctx context.Context, _ datasource.SchemaRequ
 				Computed:            true,
 			},
 			"state": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The %s state.", ItemName),
+				MarkdownDescription: "The " + ItemName + " state. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityStateValues(), true, true),
 				Computed:            true,
 			},
 			"timeouts": timeouts.Attributes(ctx),

--- a/internal/services/workspace/data_workspace.go
+++ b/internal/services/workspace/data_workspace.go
@@ -92,10 +92,12 @@ func (d *dataSourceWorkspace) Schema(ctx context.Context, _ datasource.SchemaReq
 					"blob_endpoint": schema.StringAttribute{
 						MarkdownDescription: "The OneLake API endpoint available for Blob API operations.",
 						Computed:            true,
+						CustomType:          customtypes.URLType{},
 					},
 					"dfs_endpoint": schema.StringAttribute{
 						MarkdownDescription: "The OneLake API endpoint available for Distributed File System (DFS) or ADLSgen2 filesystem API operations.",
 						Computed:            true,
+						CustomType:          customtypes.URLType{},
 					},
 				},
 			},

--- a/internal/services/workspace/data_workspace.go
+++ b/internal/services/workspace/data_workspace.go
@@ -76,9 +76,28 @@ func (d *dataSourceWorkspace) Schema(ctx context.Context, _ datasource.SchemaReq
 				Computed:            true,
 				CustomType:          customtypes.UUIDType{},
 			},
-			"capacity_assignment_progress": schema.StringAttribute{
-				MarkdownDescription: "A Workspace assignment to capacity progress status.",
+			"capacity_region": schema.StringAttribute{
+				MarkdownDescription: "The region of the capacity associated with this workspace. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityRegionValues(), true, true),
 				Computed:            true,
+			},
+			"capacity_assignment_progress": schema.StringAttribute{
+				MarkdownDescription: "A Workspace assignment to capacity progress status. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityAssignmentProgressValues(), true, true),
+				Computed:            true,
+			},
+			"onelake_endpoints": schema.SingleNestedAttribute{
+				MarkdownDescription: "The OneLake API endpoints associated with this workspace.",
+				Computed:            true,
+				CustomType:          supertypes.NewSingleNestedObjectTypeOf[oneLakeEndpointsModel](ctx),
+				Attributes: map[string]schema.Attribute{
+					"blob_endpoint": schema.StringAttribute{
+						MarkdownDescription: "The OneLake API endpoint available for Blob API operations.",
+						Computed:            true,
+					},
+					"dfs_endpoint": schema.StringAttribute{
+						MarkdownDescription: "The OneLake API endpoint available for Distributed File System (DFS) or ADLSgen2 filesystem API operations.",
+						Computed:            true,
+					},
+				},
 			},
 			"identity": schema.SingleNestedAttribute{
 				MarkdownDescription: "A workspace identity object.",

--- a/internal/services/workspace/models.go
+++ b/internal/services/workspace/models.go
@@ -83,13 +83,13 @@ func (to *workspaceIdentityModel) set(from *fabcore.WorkspaceIdentity) {
 }
 
 type oneLakeEndpointsModel struct {
-	BlobEndpoint types.String `tfsdk:"blob_endpoint"`
-	DfsEndpoint  types.String `tfsdk:"dfs_endpoint"`
+	BlobEndpoint customtypes.URL `tfsdk:"blob_endpoint"`
+	DfsEndpoint  customtypes.URL `tfsdk:"dfs_endpoint"`
 }
 
 func (to *oneLakeEndpointsModel) set(from *fabcore.OneLakeEndpoints) {
-	to.BlobEndpoint = types.StringPointerValue(from.BlobEndpoint)
-	to.DfsEndpoint = types.StringPointerValue(from.DfsEndpoint)
+	to.BlobEndpoint = customtypes.NewURLPointerValue(from.BlobEndpoint)
+	to.DfsEndpoint = customtypes.NewURLPointerValue(from.DfsEndpoint)
 }
 
 func checkWorkspaceType(entity fabcore.WorkspaceInfo) diag.Diagnostics {

--- a/internal/services/workspace/models.go
+++ b/internal/services/workspace/models.go
@@ -41,6 +41,8 @@ func (to *baseWorkspaceInfoModel) set(ctx context.Context, from fabcore.Workspac
 		oneLakeEndpoints.Set(ctx, oneLakeEndpointsModel)
 	}
 
+	to.OneLakeEndpoints = oneLakeEndpoints
+
 	workspaceIdentity := supertypes.NewSingleNestedObjectValueOfNull[workspaceIdentityModel](ctx)
 
 	if from.WorkspaceIdentity != nil {

--- a/internal/services/workspace/models.go
+++ b/internal/services/workspace/models.go
@@ -19,6 +19,8 @@ import (
 type baseWorkspaceInfoModel struct {
 	baseWorkspaceModel
 	CapacityAssignmentProgress types.String                                                 `tfsdk:"capacity_assignment_progress"`
+	CapacityRegion             types.String                                                 `tfsdk:"capacity_region"`
+	OneLakeEndpoints           supertypes.SingleNestedObjectValueOf[oneLakeEndpointsModel]  `tfsdk:"onelake_endpoints"`
 	Identity                   supertypes.SingleNestedObjectValueOf[workspaceIdentityModel] `tfsdk:"identity"`
 }
 
@@ -29,6 +31,15 @@ func (to *baseWorkspaceInfoModel) set(ctx context.Context, from fabcore.Workspac
 	to.Type = types.StringPointerValue((*string)(from.Type))
 	to.CapacityID = customtypes.NewUUIDPointerValue(from.CapacityID)
 	to.CapacityAssignmentProgress = types.StringPointerValue((*string)(from.CapacityAssignmentProgress))
+	to.CapacityRegion = types.StringPointerValue((*string)(from.CapacityRegion))
+
+	oneLakeEndpoints := supertypes.NewSingleNestedObjectValueOfNull[oneLakeEndpointsModel](ctx)
+
+	if from.OneLakeEndpoints != nil {
+		oneLakeEndpointsModel := &oneLakeEndpointsModel{}
+		oneLakeEndpointsModel.set(from.OneLakeEndpoints)
+		oneLakeEndpoints.Set(ctx, oneLakeEndpointsModel)
+	}
 
 	workspaceIdentity := supertypes.NewSingleNestedObjectValueOfNull[workspaceIdentityModel](ctx)
 
@@ -67,6 +78,16 @@ func (to *workspaceIdentityModel) set(from *fabcore.WorkspaceIdentity) {
 	to.Type = types.StringValue(workspaceIdentityTypes[0])
 	to.ApplicationID = customtypes.NewUUIDPointerValue(from.ApplicationID)
 	to.ServicePrincipalID = customtypes.NewUUIDPointerValue(from.ServicePrincipalID)
+}
+
+type oneLakeEndpointsModel struct {
+	BlobEndpoint types.String `tfsdk:"blob_endpoint"`
+	DfsEndpoint  types.String `tfsdk:"dfs_endpoint"`
+}
+
+func (to *oneLakeEndpointsModel) set(from *fabcore.OneLakeEndpoints) {
+	to.BlobEndpoint = types.StringPointerValue(from.BlobEndpoint)
+	to.DfsEndpoint = types.StringPointerValue(from.DfsEndpoint)
 }
 
 func checkWorkspaceType(entity fabcore.WorkspaceInfo) diag.Diagnostics {

--- a/internal/services/workspace/resource_workspace.go
+++ b/internal/services/workspace/resource_workspace.go
@@ -111,10 +111,12 @@ func (r *resourceWorkspace) Schema(ctx context.Context, _ resource.SchemaRequest
 					"blob_endpoint": schema.StringAttribute{
 						MarkdownDescription: "The OneLake API endpoint available for Blob API operations.",
 						Computed:            true,
+						CustomType:          customtypes.URLType{},
 					},
 					"dfs_endpoint": schema.StringAttribute{
 						MarkdownDescription: "The OneLake API endpoint available for Distributed File System (DFS) or ADLSgen2 filesystem API operations.",
 						Computed:            true,
+						CustomType:          customtypes.URLType{},
 					},
 				},
 			},

--- a/internal/services/workspace/resource_workspace.go
+++ b/internal/services/workspace/resource_workspace.go
@@ -92,11 +92,30 @@ func (r *resourceWorkspace) Schema(ctx context.Context, _ resource.SchemaRequest
 				Optional:            true,
 				CustomType:          customtypes.UUIDType{},
 			},
+			"capacity_region": schema.StringAttribute{
+				MarkdownDescription: "The region of the capacity associated with this workspace. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityRegionValues(), true, true),
+				Computed:            true,
+			},
 			"capacity_assignment_progress": schema.StringAttribute{
-				MarkdownDescription: "A Workspace assignment to capacity progress status.",
+				MarkdownDescription: "A Workspace assignment to capacity progress status. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleCapacityAssignmentProgressValues(), true, true),
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"onelake_endpoints": schema.SingleNestedAttribute{
+				MarkdownDescription: "The OneLake API endpoints associated with this workspace.",
+				Computed:            true,
+				CustomType:          supertypes.NewSingleNestedObjectTypeOf[oneLakeEndpointsModel](ctx),
+				Attributes: map[string]schema.Attribute{
+					"blob_endpoint": schema.StringAttribute{
+						MarkdownDescription: "The OneLake API endpoint available for Blob API operations.",
+						Computed:            true,
+					},
+					"dfs_endpoint": schema.StringAttribute{
+						MarkdownDescription: "The OneLake API endpoint available for Distributed File System (DFS) or ADLSgen2 filesystem API operations.",
+						Computed:            true,
+					},
 				},
 			},
 			"identity": schema.SingleNestedAttribute{

--- a/internal/testhelp/fakes/fabric_workspace.go
+++ b/internal/testhelp/fakes/fabric_workspace.go
@@ -120,9 +120,14 @@ func NewRandomWorkspaceInfo() fabcore.WorkspaceInfo {
 		ID:                         to.Ptr(testhelp.RandomUUID()),
 		DisplayName:                to.Ptr(testhelp.RandomName()),
 		Description:                to.Ptr(testhelp.RandomName()),
-		CapacityID:                 to.Ptr(testhelp.RandomUUID()),
 		Type:                       to.Ptr(fabcore.WorkspaceTypeWorkspace),
+		CapacityID:                 to.Ptr(testhelp.RandomUUID()),
+		CapacityRegion:             to.Ptr(fabcore.CapacityRegionWestUS2),
 		CapacityAssignmentProgress: to.Ptr(fabcore.CapacityAssignmentProgressCompleted),
+		OneLakeEndpoints: &fabcore.OneLakeEndpoints{
+			BlobEndpoint: to.Ptr(testhelp.RandomURI()),
+			DfsEndpoint:  to.Ptr(testhelp.RandomURI()),
+		},
 	}
 }
 


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several updates to the documentation and internal codebase to provide more detailed information about capacity and workspace attributes, including possible values for various properties.

## ✨ Description of new changes

### Documentation Updates:
* Added possible values for `region` and `state` attributes in `docs/data-sources/capacities.md`.
* Added possible values for `region` and `state` attributes in `docs/data-sources/capacity.md`.
* Added possible values for `capacity_assignment_progress` and `capacity_region` attributes, and included a nested schema for `onelake_endpoints` in `docs/data-sources/workspace.md`. [[1]](diffhunk://#diff-7cd9d7c89e4d61074ba868cdb987ff36a2cd7b06c205e0926cb33a0e37a4c586L49-R54) [[2]](diffhunk://#diff-7cd9d7c89e4d61074ba868cdb987ff36a2cd7b06c205e0926cb33a0e37a4c586R74-R82)
* Added possible values for `capacity_assignment_progress` and `capacity_region` attributes, and included a nested schema for `onelake_endpoints` in `docs/resources/workspace.md`. [[1]](diffhunk://#diff-970798ce035b018c8510aa8b7192c1834d63c06b7421c58135fab6ba4cd50d87L62-R65) [[2]](diffhunk://#diff-970798ce035b018c8510aa8b7192c1834d63c06b7421c58135fab6ba4cd50d87R92-R100)

### Codebase Updates:
* Updated `data_capacities.go` and `data_capacity.go` to include possible values for `region` and `state` attributes. [[1]](diffhunk://#diff-4920646593fa292805a70eb4ab0026515e5ede18241459f8209b62c21dabbd85L61-R69) [[2]](diffhunk://#diff-0ffc47627a176ae609e5b171aa6a1c437f1f5afc2c0bb37e640b76d33ee2d03fL61-R69)
* Updated `data_workspace.go` to include possible values for `capacity_region` and `capacity_assignment_progress` attributes, and added a nested attribute for `onelake_endpoints`.
* Updated `models.go` to include `capacity_region` and `onelake_endpoints` attributes in the `baseWorkspaceInfoModel` struct and added corresponding setter functions. [[1]](diffhunk://#diff-00d96b63ceb514d3dfda5f1c4f15e2c2e704fcddbef588e09985d8063b980a3eR22-R23) [[2]](diffhunk://#diff-00d96b63ceb514d3dfda5f1c4f15e2c2e704fcddbef588e09985d8063b980a3eR34-R42) [[3]](diffhunk://#diff-00d96b63ceb514d3dfda5f1c4f15e2c2e704fcddbef588e09985d8063b980a3eR83-R92)
* Updated `resource_workspace.go` to include possible values for `capacity_region` and `capacity_assignment_progress` attributes, and added a nested attribute for `onelake_endpoints`.
* Updated `fabric_workspace.go` to include `capacity_region` and `onelake_endpoints` in the `NewRandomWorkspaceInfo` function.