### PR TITLE
fix(rs-lakehouse): creation failing when enable_schemas is false

### DIFF
--- a/.changes/unreleased/fixed-20241011-205500.yaml
+++ b/.changes/unreleased/fixed-20241011-205500.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: '`fabric_lakehouse` Resource creation failed when `configuration.enable_schemas` has been set to `false`'
+time: 2024-10-11T20:55:00.0241833+02:00
+custom:
+    Issue: "47"

--- a/internal/services/lakehouse/models_resource_lakehouse.go
+++ b/internal/services/lakehouse/models_resource_lakehouse.go
@@ -35,7 +35,7 @@ func (to *requestCreateLakehouse) set(ctx context.Context, from resourceLakehous
 			return diags
 		}
 
-		if !configuration.EnableSchemas.IsNull() && !configuration.EnableSchemas.IsUnknown() {
+		if configuration.EnableSchemas.ValueBool() {
 			to.CreationPayload = &fablakehouse.CreationPayload{
 				EnableSchemas: configuration.EnableSchemas.ValueBoolPointer(),
 			}

--- a/internal/services/lakehouse/resource_lakehouse_test.go
+++ b/internal/services/lakehouse/resource_lakehouse_test.go
@@ -271,9 +271,13 @@ func TestAcc_LakehouseResource_CRUD(t *testing.T) {
 
 func TestAcc_LakehouseConfigurationResource_CRUD(t *testing.T) {
 	workspaceID := *testhelp.WellKnown().Workspace.ID
-	entityCreateDisplayName := testhelp.RandomName()
-	entityUpdateDisplayName := testhelp.RandomName()
-	entityUpdateDescription := testhelp.RandomName()
+	entityCreateDisplayName1 := testhelp.RandomName()
+	entityUpdateDisplayName1 := testhelp.RandomName()
+	entityUpdateDescription1 := testhelp.RandomName()
+
+	entityCreateDisplayName2 := testhelp.RandomName()
+	entityUpdateDisplayName2 := testhelp.RandomName()
+	entityUpdateDescription2 := testhelp.RandomName()
 
 	resource.Test(t, testhelp.NewTestAccCase(t, &testResourceItemFQN, nil, []resource.TestStep{
 		// Create and Read (configuration)
@@ -283,14 +287,14 @@ func TestAcc_LakehouseConfigurationResource_CRUD(t *testing.T) {
 				testResourceItemHeader,
 				map[string]any{
 					"workspace_id": workspaceID,
-					"display_name": entityCreateDisplayName,
+					"display_name": entityCreateDisplayName1,
 					"configuration": map[string]any{
 						"enable_schemas": true,
 					},
 				},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityCreateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityCreateDisplayName1),
 				resource.TestCheckResourceAttr(testResourceItemFQN, "description", ""),
 				resource.TestCheckResourceAttr(testResourceItemFQN, "configuration.enable_schemas", "true"),
 				resource.TestCheckResourceAttr(testResourceItemFQN, "properties.default_schema", "dbo"),
@@ -303,18 +307,59 @@ func TestAcc_LakehouseConfigurationResource_CRUD(t *testing.T) {
 				testResourceItemHeader,
 				map[string]any{
 					"workspace_id": workspaceID,
-					"display_name": entityUpdateDisplayName,
-					"description":  entityUpdateDescription,
+					"display_name": entityUpdateDisplayName1,
+					"description":  entityUpdateDescription1,
 					"configuration": map[string]any{
 						"enable_schemas": true,
 					},
 				},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName),
-				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName1),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription1),
 				resource.TestCheckResourceAttr(testResourceItemFQN, "configuration.enable_schemas", "true"),
 				resource.TestCheckResourceAttr(testResourceItemFQN, "properties.default_schema", "dbo"),
+			),
+		},
+		// Create and Read (configuration)
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"workspace_id": workspaceID,
+					"display_name": entityCreateDisplayName2,
+					"configuration": map[string]any{
+						"enable_schemas": false,
+					},
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityCreateDisplayName2),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", ""),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "configuration.enable_schemas", "false"),
+				resource.TestCheckNoResourceAttr(testResourceItemFQN, "properties.default_schema"),
+			),
+		},
+		// Update and Read (configuration)
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"workspace_id": workspaceID,
+					"display_name": entityUpdateDisplayName2,
+					"description":  entityUpdateDescription2,
+					"configuration": map[string]any{
+						"enable_schemas": false,
+					},
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName2),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription2),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "configuration.enable_schemas", "false"),
+				resource.TestCheckNoResourceAttr(testResourceItemFQN, "properties.default_schema"),
 			),
 		},
 	},


### PR DESCRIPTION
# 📥 Pull Request

close #41

## ❓ What are you trying to address

This pull request addresses a bug fix in the `fabric_lakehouse` resource creation and enhances the test coverage for different configurations. The key changes include fixing the resource creation logic when schemas are disabled and expanding the test cases to cover more scenarios.

## ✨ Description of new changes

### Bug Fixes:
* [`.changes/unreleased/fixed-20241011-205500.yaml`](diffhunk://#diff-f0c6196f7cc4d5f0d02c62d97da4755c989a3f0741826bc18bd99d816e0a3931R1-R5): Added a new entry to document the fix for the `fabric_lakehouse` resource creation failure when `configuration.enable_schemas` is set to `false`.
* [`internal/services/lakehouse/models_resource_lakehouse.go`](diffhunk://#diff-21525041e68a2b1aa2a83bd03af29dbd976f98b5893b2da2edff25b312968068L38-R38): Corrected the condition to check if `configuration.EnableSchemas` is set to `true` before setting the `CreationPayload`.

### Test Enhancements:
* [`internal/services/lakehouse/resource_lakehouse_test.go`](diffhunk://#diff-788480643cece417ede65d6272edcd8a19d268328028f2712488483c40d61a3eL274-R280): Updated the `TestAcc_LakehouseConfigurationResource_CRUD` test to include additional test cases for creating and updating resources with different `display_name` and `description` values, and both enabled and disabled schemas configurations. [[1]](diffhunk://#diff-788480643cece417ede65d6272edcd8a19d268328028f2712488483c40d61a3eL274-R280) [[2]](diffhunk://#diff-788480643cece417ede65d6272edcd8a19d268328028f2712488483c40d61a3eL286-R297) [[3]](diffhunk://#diff-788480643cece417ede65d6272edcd8a19d268328028f2712488483c40d61a3eL306-R364)