### PR TITLE
test: extend timeout for tests from 15 to 30 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
   checkbuild:
     name: 🏗️ Check Build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -321,7 +321,7 @@ jobs:
     environment:
       name: development
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       actions: read
@@ -416,7 +416,7 @@ jobs:
       - name: 🧪 Run tests
         if: matrix.cli == 'terraform' && (steps.changes_check.outputs.changes == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
         run: task test
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           FABRIC_TESTACC_SKIP_NO_SPN: true
           FABRIC_USE_OIDC: true
@@ -426,7 +426,7 @@ jobs:
       - name: 🧪 Run tests
         if: matrix.cli == 'tofu' && (steps.changes_check.outputs.changes == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
         run: task test
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           FABRIC_TESTACC_SKIP_NO_SPN: true
           FABRIC_USE_OIDC: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -280,8 +280,8 @@ tasks:
     desc: Run acceptance tests
     cmds:
       - go clean -testcache
-      - '{{if eq .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format github-actions --junitfile "testresults.xml" -- ./... -run "^TestAcc_{{.TEST_NAME}}" -timeout 15m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic{{end}}'
-      - '{{if ne .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format pkgname-and-test-fails --junitfile "testresults.xml" -- ./... -run "^TestAcc_{{.TEST_NAME}}" -timeout 15m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic{{end}}'
+      - '{{if eq .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format github-actions --junitfile "testresults.xml" -- ./... -run "^TestAcc_{{.TEST_NAME}}" -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic{{end}}'
+      - '{{if ne .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format pkgname-and-test-fails --junitfile "testresults.xml" -- ./... -run "^TestAcc_{{.TEST_NAME}}" -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic{{end}}'
       - task: test:getcover
     vars:
       TEST_NAME: '{{if ne .CLI_ARGS ""}}{{.CLI_ARGS}}{{end}}'
@@ -295,8 +295,8 @@ tasks:
     cmds:
       - go clean -testcache
       - go test -failfast -run ^TestDevEnv_Provision$ {{.MODULE_NAME}}/internal/testhelp
-      - '{{if eq .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format github-actions --junitfile "testresults.xml" -- ./... -run "^Test(Acc|Unit)_{{.TEST_NAME}}" -timeout 15m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic -coverpkg={{.GO_PKGS}}{{end}}'
-      - '{{if ne .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format pkgname-and-test-fails --junitfile "testresults.xml" -- ./... -run "^Test(Acc|Unit)_{{.TEST_NAME}}" -timeout 15m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic -coverpkg={{.GO_PKGS}}{{end}}'
+      - '{{if eq .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format github-actions --junitfile "testresults.xml" -- ./... -run "^Test(Acc|Unit)_{{.TEST_NAME}}" -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic -coverpkg={{.GO_PKGS}}{{end}}'
+      - '{{if ne .GITHUB_ACTIONS "true"}}gotestsum --format-hivis --format pkgname-and-test-fails --junitfile "testresults.xml" -- ./... -run "^Test(Acc|Unit)_{{.TEST_NAME}}" -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic -coverpkg={{.GO_PKGS}}{{end}}'
       - task: test:getcover
     vars:
       TEST_NAME: '{{if ne .CLI_ARGS ""}}{{.CLI_ARGS}}{{end}}'


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

- Sometimes, tests in the pipeline may take slightly longer that 15 minutes to complete
- If that happens, the pipeline will fail due to the timeout
- This PR extends the timeout for tests from 15 to 30 minutes to prevent pipeline failures
- 
## ✨ Description of new changes

- Extend timeout for tests from 15 to 30 minutes

## ☑️ PR Checklist

- [x] Ensure the PR description clearly describes the feature you're adding and any known limitations

