### PR TITLE
fix(lint): go code linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,10 +49,6 @@ issues:
 linters:
   enable-all: true
   disable:
-    # deprecated - start
-    - gomnd
-    - execinquery
-    # deprecated - end
     - depguard
     - exhaustruct
     - lll
@@ -105,6 +101,8 @@ linters-settings:
       - name: cyclomatic
         disabled: true
       - name: if-return
+        disabled: true
+      - name: max-public-structs
         disabled: true
 
   nestif:

--- a/internal/functions/content_decode.go
+++ b/internal/functions/content_decode.go
@@ -25,11 +25,11 @@ func NewFunctionContentDecode() function.Function {
 
 type functionContentDecode struct{}
 
-func (f functionContentDecode) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+func (f *functionContentDecode) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
 	resp.Name = "content_decode"
 }
 
-func (f functionContentDecode) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+func (f *functionContentDecode) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Summary:             "Decode a Definition JSON object.",
 		MarkdownDescription: "Given a Base64 Gzip encoded content, will decode and return a Definition JSON object representation of that resource.",


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several changes to the `.golangci.yml` configuration file and a modification to the `functionContentDecode` struct methods in `internal/functions/content_decode.go` to fix linting issues.

## ✨ Description of new changes

### Configuration updates:

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L52-L55): Removed deprecated linters `gomnd` and `execinquery` from the `disable` list.
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R105-R106): Added `max-public-structs` to the `linters-settings` section and disabled it.

### Codebase improvements:

* [`internal/functions/content_decode.go`](diffhunk://#diff-b2e4153446202790f72e0a5ae2d1c5c71195dd56d78c927733a968f565730f46L28-R32): Changed the receiver type of methods `Metadata` and `Definition` from value receiver to pointer receiver for the `functionContentDecode` struct.
