### PR TITLE
fix(workspace): update resource creation to handle state correctly for identity

### DIFF
--- a/.changes/unreleased/fixed-20241119-215139.yaml
+++ b/.changes/unreleased/fixed-20241119-215139.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Create Identity with Fabric workspace failed due to inconsistent result after apply
+time: 2024-11-19T21:51:39.7634679-08:00
+custom:
+    Issue: "93"

--- a/.changes/unreleased/fixed-20241122-130758.yaml
+++ b/.changes/unreleased/fixed-20241122-130758.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Deprovision Workspace Identity during destroy Workspace operation
+time: 2024-11-22T13:07:58.7068428-08:00
+custom:
+    Issue: "96"

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -11,6 +11,7 @@ const (
 	ErrorInvalidValue                 string = "Invalid Value"
 	ErrorAttComboInvalid              string = "Invalid Attribute Combination"
 	ErrorAttConfigMissing             string = "Missing Attribute Configuration"
+	ErrorAttValueMatch                string = "Invalid Attribute Value Match"
 	ErrorDataSourceConfigType         string = "Unexpected Data Source Configure Type"
 	ErrorResourceConfigType           string = "Unexpected Resource Configure Type"
 	ErrorModelConversion              string = "Data Model Conversion Error"

--- a/internal/services/domain/resource_domain_role_assignments_test.go
+++ b/internal/services/domain/resource_domain_role_assignments_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/microsoft/fabric-sdk-go/fabric/admin"
 
+	"github.com/microsoft/terraform-provider-fabric/internal/common"
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/services/domain"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -84,7 +85,7 @@ func TestUnit_DomainRoleAssignmentsResource_Attributes(t *testing.T) {
 					"role":       "invalid role",
 				},
 			),
-			ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
+			ExpectError: regexp.MustCompile(common.ErrorAttValueMatch),
 		},
 		// error - no required attributes - principals[0].id
 		{

--- a/internal/services/kqldatabase/resource_kql_database_test.go
+++ b/internal/services/kqldatabase/resource_kql_database_test.go
@@ -112,7 +112,7 @@ func TestUnit_KQLDatabaseResource_Attributes(t *testing.T) {
 					},
 				},
 			),
-			ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
+			ExpectError: regexp.MustCompile(common.ErrorAttValueMatch),
 		},
 		// error - source_database_name - unexpected attribute
 		{

--- a/internal/services/workspace/resource_workspace.go
+++ b/internal/services/workspace/resource_workspace.go
@@ -522,7 +522,6 @@ func (r *resourceWorkspace) Delete(ctx context.Context, req resource.DeleteReque
 		}
 
 		if !identityState.ApplicationID.IsNull() && !identityState.ApplicationID.IsUnknown() {
-
 			tflog.Debug(ctx, "DEPROVISION IDENTITY", map[string]any{
 				"action": "start",
 				"id":     state.ID.ValueString(),

--- a/internal/services/workspace/resource_workspace_git_test.go
+++ b/internal/services/workspace/resource_workspace_git_test.go
@@ -10,6 +10,7 @@ import (
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
+	"github.com/microsoft/terraform-provider-fabric/internal/common"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp/fakes"
 )
@@ -95,7 +96,7 @@ func TestUnit_WorkspaceGitResource(t *testing.T) {
 					"git_provider_details":    testHelperGitProviderDetails,
 				},
 			),
-			ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
+			ExpectError: regexp.MustCompile(common.ErrorAttValueMatch),
 		},
 		// error - invalid git_provider_type
 		{
@@ -108,7 +109,7 @@ func TestUnit_WorkspaceGitResource(t *testing.T) {
 					"git_provider_details":    testCaseInvalidGitProviderType,
 				},
 			),
-			ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
+			ExpectError: regexp.MustCompile(common.ErrorAttValueMatch),
 		},
 		// error - invalid directory_name
 		{
@@ -121,7 +122,7 @@ func TestUnit_WorkspaceGitResource(t *testing.T) {
 					"git_provider_details":    testCaseInvalidDirectoryName,
 				},
 			),
-			ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
+			ExpectError: regexp.MustCompile(common.ErrorAttValueMatch),
 		},
 		// error - missing branch_name
 		{

--- a/internal/services/workspace/resource_workspace_test.go
+++ b/internal/services/workspace/resource_workspace_test.go
@@ -299,3 +299,121 @@ func TestAcc_WorkspaceResource_CRUD(t *testing.T) {
 	},
 	))
 }
+
+func TestAcc_WorkspaceResource_Identity_CRUD(t *testing.T) {
+	capacityID := *testhelp.WellKnown().Capacity.ID
+	entityCreateDisplayName := testhelp.RandomName()
+	entityUpdateDisplayName := testhelp.RandomName()
+	entityUpdateDescription := testhelp.RandomName()
+
+	resource.Test(t, testhelp.NewTestAccCase(t, &testResourceItemFQN, nil, []resource.TestStep{
+		// Create and Read
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": entityCreateDisplayName,
+					"capacity_id":  capacityID,
+					"identity": map[string]any{
+						"type": "SystemAssigned",
+					},
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityCreateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", ""),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "capacity_id", capacityID),
+				resource.TestCheckResourceAttrSet(testResourceItemFQN, "identity.application_id"),
+			),
+		},
+		// Update and Read
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": entityUpdateDisplayName,
+					"description":  entityUpdateDescription,
+					"capacity_id":  capacityID,
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "capacity_id", capacityID),
+			),
+		},
+		// Update - unassign capacity
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": entityUpdateDisplayName,
+					"description":  entityUpdateDescription,
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription),
+				resource.TestCheckNoResourceAttr(testResourceItemFQN, "capacity_id"),
+			),
+		},
+		// Update - assign capacity
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": entityUpdateDisplayName,
+					"description":  entityUpdateDescription,
+					"capacity_id":  capacityID,
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "capacity_id", capacityID),
+			),
+		},
+		// Update - unassign identity
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": entityUpdateDisplayName,
+					"description":  entityUpdateDescription,
+					"capacity_id":  capacityID,
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription),
+				resource.TestCheckNoResourceAttr(testResourceItemFQN, "identity"),
+			),
+		},
+		// Update - assign identity
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": entityUpdateDisplayName,
+					"description":  entityUpdateDescription,
+					"capacity_id":  capacityID,
+					"identity": map[string]any{
+						"type": "SystemAssigned",
+					},
+				},
+			),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceItemFQN, "display_name", entityUpdateDisplayName),
+				resource.TestCheckResourceAttr(testResourceItemFQN, "description", entityUpdateDescription),
+				resource.TestCheckResourceAttrSet(testResourceItemFQN, "identity.application_id"),
+			),
+		},
+	},
+	))
+}

--- a/internal/services/workspace/resource_workspace_test.go
+++ b/internal/services/workspace/resource_workspace_test.go
@@ -83,6 +83,21 @@ func TestUnit_WorkspaceResource_Attributes(t *testing.T) {
 			),
 			ExpectError: regexp.MustCompile(common.ErrorAttConfigMissing),
 		},
+		// error - invalid identity type
+		{
+			ResourceName: testResourceItemFQN,
+			Config: at.CompileConfig(
+				testResourceItemHeader,
+				map[string]any{
+					"display_name": "test",
+					"capacity_id":  "00000000-0000-0000-0000-000000000000",
+					"identity": map[string]any{
+						"type": "Test",
+					},
+				},
+			),
+			ExpectError: regexp.MustCompile(common.ErrorAttValueMatch),
+		},
 	}))
 }
 


### PR DESCRIPTION
# 📥 Pull Request

fix #93

## ❓ What are you trying to address

This pull request includes changes to the `Create` method in the `resourceWorkspace` struct to improve state management and ensure that the state is properly updated. The most important changes include initializing the `state` variable, setting `state.Timeouts` and `state.ID`, and updating the `get` and `Set` methods to use `state` instead of `plan`.

## ✨ Description of new changes

State management improvements:

* [`internal/services/workspace/resource_workspace.go`](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608L207-R207): Initialized the `state` variable alongside `plan`.
* [`internal/services/workspace/resource_workspace.go`](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608R221-R222): Set `state.Timeouts` to `plan.Timeouts`.
* [`internal/services/workspace/resource_workspace.go`](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608R233-R239): Set `state.ID` to `plan.ID`.
* [`internal/services/workspace/resource_workspace.go`](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608R233-R239): Updated the `get` method to use `state` instead of `plan`. [[1]](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608R233-R239) [[2]](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608L266-R273)
* [`internal/services/workspace/resource_workspace.go`](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608R233-R239): Updated the `Set` method to use `state` instead of `plan`. [[1]](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608R233-R239) [[2]](diffhunk://#diff-87c99c17b488a2914da585da7b4f1eacb8b55b7439c0f8a2cff0c51753da2608L266-R273)
