### PR TITLE
fix(ci): Remove the package name from the flags used to set main.version during the release process

### DIFF
--- a/.changes/unreleased/fixed-20241121-214245.yaml
+++ b/.changes/unreleased/fixed-20241121-214245.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Remove the package name from the flags used to set main.version during the release process
+time: 2024-11-21T21:42:45.530221257Z
+custom:
+    Issue: "102"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X {{ .ModulePath }}/main.version={{ .Version }}"
+      - "-s -w -X main.version={{ .Version }}"
     goos:
       - freebsd
       - windows

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -271,7 +271,7 @@ tasks:
       - task: test:getcover
     vars:
       TEST_NAME: '{{if ne .CLI_ARGS ""}}{{.CLI_ARGS}}{{end}}'
-      LDFLAGS: "-s -w -X {{.MODULE_NAME}}/main.version=testUnit"
+      LDFLAGS: "-s -w -X main.version=testUnit"
     env:
       TF_LOG: error
       TF_ACC: 0
@@ -285,7 +285,7 @@ tasks:
       - task: test:getcover
     vars:
       TEST_NAME: '{{if ne .CLI_ARGS ""}}{{.CLI_ARGS}}{{end}}'
-      LDFLAGS: "-s -w -X {{.MODULE_NAME}}/main.version=testAcc"
+      LDFLAGS: "-s -w -X main.version=testAcc"
     env:
       TF_LOG: error
       TF_ACC: 1
@@ -300,7 +300,7 @@ tasks:
       - task: test:getcover
     vars:
       TEST_NAME: '{{if ne .CLI_ARGS ""}}{{.CLI_ARGS}}{{end}}'
-      LDFLAGS: "-s -w -X {{.MODULE_NAME}}/main.version=testAcc"
+      LDFLAGS: "-s -w -X main.version=testAcc"
       GO_PKGS_EXCLUDE: "/testhelp|/fakes|/terraform-provider-fabric"
       GO_PKGS:
         sh: |

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -24,9 +25,16 @@ var version = "dev"
 
 func main() {
 	var debug bool
+	var printVersion bool
 
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.BoolVar(&printVersion, "version", false, "print the version")
 	flag.Parse()
+
+	if printVersion {
+		fmt.Printf("Version: %s\n", version)
+		return
+	}
 
 	opts := providerserver.ServeOpts{
 		Address: "registry.terraform.io/microsoft/fabric",

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -32,7 +31,8 @@ func main() {
 	flag.Parse()
 
 	if printVersion {
-		fmt.Printf("Version: %s\n", version)
+		log.Printf("Version: %s\n", version)
+
 		return
 	}
 


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

- The `main.version` value is not being properly updated during the build and release process, leaving the default `dev` value unmodified
- Fixes #102 

## ✨ Description of new changes

- Now, the package name is removed from the flags used to set main.version during the release process. It only passes `main.version=<version>`
- If the provider binary is executed as a standalone binary, it will print the version and exit.
