### PR TITLE
test: remove SPN skip from eventhouses and semantic models tests

### DIFF
--- a/internal/services/eventhouse/data_eventhouses_test.go
+++ b/internal/services/eventhouse/data_eventhouses_test.go
@@ -75,10 +75,6 @@ func TestUnit_EventhousesDataSource(t *testing.T) {
 }
 
 func TestAcc_EventhousesDataSource(t *testing.T) {
-	if testhelp.ShouldSkipTest(t) {
-		t.Skip("No SPN support")
-	}
-
 	workspaceID := *testhelp.WellKnown().Workspace.ID
 
 	resource.ParallelTest(t, testhelp.NewTestAccCase(t, nil, nil, []resource.TestStep{

--- a/internal/services/semanticmodel/data_semantic_models_test.go
+++ b/internal/services/semanticmodel/data_semantic_models_test.go
@@ -75,10 +75,6 @@ func TestUnit_SemanticModelsDataSource(t *testing.T) {
 }
 
 func TestAcc_SemanticModelsDataSource(t *testing.T) {
-	if testhelp.ShouldSkipTest(t) {
-		t.Skip("No SPN support")
-	}
-
 	workspaceID := *testhelp.WellKnown().Workspace.ID
 
 	resource.ParallelTest(t, testhelp.NewTestAccCase(t, nil, nil, []resource.TestStep{


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes changes to remove conditional test skips in the `internal/services/eventhouse/data_eventhouses_test.go` and `internal/services/semanticmodel/data_semantic_models_test.go` files. The most important changes include removing the `testhelp.ShouldSkipTest` checks from the affected test functions.

## ✨ Description of new changes

* [`internal/services/eventhouse/data_eventhouses_test.go`](diffhunk://#diff-d9e4745346ceb6b5e1e0db0b1d6ca4bf65525ef2b056c76203700fd592e81c4cL78-L81): Removed the conditional skip check for SPN support in the `TestAcc_EventhousesDataSource` test function.
* [`internal/services/semanticmodel/data_semantic_models_test.go`](diffhunk://#diff-018ed8f2e732aaa3c238a1294df9d5d1c946cb03752d7af1b23d5af37da9c1adL78-L81): Removed the conditional skip check for SPN support in the `TestAcc_SemanticModelsDataSource` test function.