### PR TITLE
fix(ws-git): remove github from docs

### DIFF
--- a/.changes/unreleased/fixed-20241125-090146.yaml
+++ b/.changes/unreleased/fixed-20241125-090146.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Removed info about GitHub support in the docs, which one is not yet supported in provider.
+time: 2024-11-25T09:01:46.6991069-08:00
+custom:
+  Issue: "108"

--- a/docs/data-sources/workspace_git.md
+++ b/docs/data-sources/workspace_git.md
@@ -51,7 +51,7 @@ Read-Only:
 
 - `branch_name` (String) The branch name.
 - `directory_name` (String) The directory name.
-- `git_provider_type` (String) The Git provider type. Possible values: `AzureDevOps`, `GitHub`
+- `git_provider_type` (String) The Git provider type. Possible values: `AzureDevOps`
 - `organization_name` (String) The organization name.
 - `project_name` (String) The project name.
 - `repository_name` (String) The repository name.

--- a/docs/resources/workspace_git.md
+++ b/docs/resources/workspace_git.md
@@ -60,7 +60,7 @@ Required:
 
 - `branch_name` (String) The branch name.
 - `directory_name` (String) The directory name.
-- `git_provider_type` (String) The Git provider type. Accepted values: `AzureDevOps`, `GitHub`
+- `git_provider_type` (String) The Git provider type. Accepted values: `AzureDevOps`
 - `organization_name` (String) The organization name.
 - `project_name` (String) The project name.
 - `repository_name` (String) The repository name.

--- a/internal/services/workspace/data_workspace_git.go
+++ b/internal/services/workspace/data_workspace_git.go
@@ -72,7 +72,7 @@ func (d *dataSourceWorkspaceGit) Schema(ctx context.Context, _ datasource.Schema
 				CustomType:          supertypes.NewSingleNestedObjectTypeOf[gitProviderDetailsModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"git_provider_type": schema.StringAttribute{
-						MarkdownDescription: "The Git provider type. Possible values: " + utils.ConvertStringSlicesToString(fabcore.PossibleGitProviderTypeValues(), true, true),
+						MarkdownDescription: "The Git provider type. Possible values: " + utils.ConvertStringSlicesToString(utils.RemoveSliceByValue(fabcore.PossibleGitProviderTypeValues(), fabcore.GitProviderTypeGitHub), true, true),
 						Computed:            true,
 					},
 					"organization_name": schema.StringAttribute{

--- a/internal/services/workspace/resource_workspace_git.go
+++ b/internal/services/workspace/resource_workspace_git.go
@@ -101,10 +101,10 @@ func (r *resourceWorkspaceGit) Schema(ctx context.Context, _ resource.SchemaRequ
 				},
 				Attributes: map[string]schema.Attribute{
 					"git_provider_type": schema.StringAttribute{
-						MarkdownDescription: "The Git provider type. Accepted values: " + utils.ConvertStringSlicesToString(fabcore.PossibleGitProviderTypeValues(), true, true),
+						MarkdownDescription: "The Git provider type. Accepted values: " + utils.ConvertStringSlicesToString(utils.RemoveSliceByValue(fabcore.PossibleGitProviderTypeValues(), fabcore.GitProviderTypeGitHub), true, true),
 						Required:            true,
 						Validators: []validator.String{
-							stringvalidator.OneOf(utils.ConvertEnumsToStringSlices(fabcore.PossibleGitProviderTypeValues(), true)...),
+							stringvalidator.OneOf(utils.ConvertEnumsToStringSlices(utils.RemoveSliceByValue(fabcore.PossibleGitProviderTypeValues(), fabcore.GitProviderTypeGitHub), true)...),
 						},
 					},
 					"organization_name": schema.StringAttribute{


### PR DESCRIPTION
# 📥 Pull Request

close #108 

## ❓ What are you trying to address

This pull request includes changes to remove references to GitHub support from the documentation and codebase, as it is not yet supported by the provider. The most important changes include updates to documentation files and schema definitions to reflect this removal.

## ✨ Description of new changes

Documentation updates:

* [`docs/data-sources/workspace_git.md`](diffhunk://#diff-ba680457622059b12ddb69bf491cf0ee36bfe48dc00990359cf69e521cde8668L54-R54): Removed `GitHub` from the possible values of `git_provider_type`.
* [`docs/resources/workspace_git.md`](diffhunk://#diff-f260a1fbe1e8258810be5d024e7e841b9c6ff1392c1dd4ddb68eba2b916ffaabL63-R63): Removed `GitHub` from the accepted values of `git_provider_type`.

Code updates:

* [`internal/services/workspace/data_workspace_git.go`](diffhunk://#diff-07308d0bd0e45b8563657cbc1d9295472d7ee2b0592ecd51f534baf6a05928a3L75-R75): Updated the `MarkdownDescription` for `git_provider_type` to exclude `GitHub` from the possible values.
* [`internal/services/workspace/resource_workspace_git.go`](diffhunk://#diff-8ea71ad0c29e683008856937c4a73ecc8addbfa05ec32964f37d0e606bf83e3cL104-R107): Updated the `MarkdownDescription` and validators for `git_provider_type` to exclude `GitHub` from the accepted values.
