### PR TITLE
build(deps): update terraform and tofu

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,13 +36,13 @@
     // "ghcr.io/guiyomh/features/gomarkdoc:0": {},
     // "ghcr.io/guiyomh/features/gotestsum:0": {},
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.9.8",
+      "version": "1.10.0",
       "installSentinel": true,
       "installTFsec": true,
       "installTerraformDocs": true
     },
     "ghcr.io/robbert229/devcontainer-features/opentofu:1": {
-      "version": "1.8.5"
+      "version": "1.8.6"
     },
     "ghcr.io/devcontainers-contrib/features/pipx-package:1": {},
     // "ghcr.io/devcontainers-contrib/features/mkdocs:2": {},

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,7 +420,7 @@ jobs:
         run: task test
         timeout-minutes: 30
         env:
-          TF_LOG: DEBUG
+          # TF_LOG: DEBUG
           FABRIC_TESTACC_SKIP_NO_SPN: true
           FABRIC_USE_OIDC: true
           FABRIC_TENANT_ID: ${{ secrets.TESTACC_TENANT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -334,12 +334,14 @@ jobs:
       fail-fast: false
       matrix:
         cli: [terraform, tofu]
-        version: ["1.7", "1.8", "1.9"]
+        version: ["1.7", "1.8", "1.9", "1.10"]
         exclude:
           - cli: terraform
             version: "1.7"
           - cli: tofu
             version: "1.9"
+          - cli: tofu
+            version: "1.10"
     steps:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -418,6 +420,7 @@ jobs:
         run: task test
         timeout-minutes: 30
         env:
+          TF_LOG: DEBUG
           FABRIC_TESTACC_SKIP_NO_SPN: true
           FABRIC_USE_OIDC: true
           FABRIC_TENANT_ID: ${{ secrets.TESTACC_TENANT_ID }}
@@ -502,7 +505,7 @@ jobs:
       - name: 📥 Download
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          pattern: terraform-1_9-test-coverage*
+          pattern: terraform-1_10-test-coverage*
           merge-multiple: true
 
       - name: 📝 Publish


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the Terraform and Tofu versions used in the development container and GitHub Actions workflows, as well as some environment configuration changes for testing.

## ✨ Description of new changes

### Version Updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L39-R45): Updated Terraform version from `1.9.8` to `1.10.0` and Tofu version from `1.8.5` to `1.8.6`.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L337-R344): Added support for Terraform version `1.10` and excluded Tofu version `1.10` from specific tests.

### Environment Configuration:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R423): Added `TF_LOG: DEBUG` to the environment variables for the test job.

### Test Artifact Handling:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L505-R508): Updated the artifact download pattern to match Terraform version `1.10` test coverage files.