### PR TITLE
build(deps): bump Go version from 1.23.3 to 1.23.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     },
     // "ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.23.3"
+      "version": "1.23.4"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/terraform-provider-fabric
 
-go 1.23.3
+go 1.23.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the Go version used in the project.

## ✨ Description of new changes

* Updated the Go version in `.devcontainer/devcontainer.json` from `1.23.3` to `1.23.4`.
* Updated the Go version in `go.mod` from `1.23.3` to `1.23.4`.