### PR TITLE
docs(guides): improve formatting in getting started

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -46,3 +46,6 @@ replacements:
   - path: ./examples/provider/provider.tf
     find: ' version = ".*"'
     replace: ' version = "{{.VersionNoPrefix}}"'
+  - path: ./templates/guides/getting_started.md.tmpl
+    find: '          version = ".*"'
+    replace: '          version = "{{.VersionNoPrefix}}"'

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -7,13 +7,13 @@ description: |-
 
 # Getting started
 
-[HashiCorp Terraform](https://www.terraform.io/) is a popular open source tool for creating safe and predictable cloud infrastructure across several cloud providers.
+[HashiCorp Terraform](https://www.terraform.io/) is a popular open-source tool for creating safe and predictable cloud infrastructure across several cloud providers.
 You can use the Microsoft Fabric Terraform Provider to manage your Microsoft Fabric workspaces using a flexible, powerful tool.
 The goal of the Microsoft Fabric Terraform Provider is to support automation of the most complicated aspects of deploying and managing Microsoft Fabric.
 Microsoft Fabric customers are using the Microsoft Fabric Terraform Provider to deploy and manage clusters and jobs and to configure data access.
 
 In this section, you install and configure requirements to use Terraform and the Microsoft Fabric Terraform Provider on your local development machine.
-You then configure Terraform authentication. Following this section, this article provides a sample configuration that you can experiment with to provision a Microsoft Fabric notebook and lakehouse.
+You then configure Terraform authentication. Following this section, this article provides a sample configuration that you can experiment with to provision a Microsoft Fabric Notebook and Lakehouse.
 
 ## Requirements
 
@@ -32,30 +32,30 @@ You then configure Terraform authentication. Following this section, this articl
 
 ## Sample configuration
 
-This section provides a sample configuration that you can experiment with to provision a Microsoft Fabric notebook and a lakehouse. It assumes that you have already set up the requirements, as well as created a Terraform project and configured the project with Terraform authentication as described in the previous section.
+This section provides a sample configuration that you can experiment with to provision a Microsoft Fabric Notebook and a Lakehouse. It assumes that you have already set up the requirements, as well as created a Terraform project and configured the project with Terraform authentication as described in the previous section.
 
 1. Create a new file named `provider.tf` in your Terraform project directory.
 1. Add the following code to `provider.tf` to define a dependency on the Microsoft Fabric Terraform Provider:
 
-```terraform
-# We strongly recommend using the required_providers block to set the Fabric Provider source and version being used
-terraform {
-  required_version = ">= 1.8, < 2.0"
-  required_providers {
-    fabric = {
-      source  = "microsoft/fabric"
-      version = "0.1.0-beta.6"
+    ```terraform
+    # We strongly recommend using the required_providers block to set the Fabric Provider source and version being used
+    terraform {
+      required_version = ">= 1.8, < 2.0"
+      required_providers {
+        fabric = {
+          source  = "microsoft/fabric"
+          version = "0.1.0-beta.6"
+        }
+      }
     }
-  }
-}
 
-# Configure the Microsoft Fabric Terraform Provider
-provider "fabric" {
-  # Configuration options
-}
-```
+    # Configure the Microsoft Fabric Terraform Provider
+    provider "fabric" {
+      # Configuration options
+    }
+    ```
 
-1. Create another file named `variables.tf`, and add the following code. This file represents input variables that can be used to configure a notebook and lakehouse.
+1. Create another file named `variables.tf`, and add the following code. This file represents input variables that can be used to configure a Notebook and Lakehouse.
 
     ```terraform
     variable "workspace_display_name" {
@@ -85,8 +85,7 @@ provider "fabric" {
     }
     ```
 
-1. Create a file named `workspace.tf` and add the following hcl code to represent a
-Microsoft Fabric workspace. We will also add a data source to fetch the Microsoft Fabric Capacity id by name (see requirements section).
+1. Create a file named `workspace.tf` and add the following hcl code to represent a Microsoft Fabric workspace. We will also add a data source to fetch the Microsoft Fabric Capacity id by name (see requirements section).
 
     ```terraform
     data "fabric_capacity" "capacity" {
@@ -101,7 +100,7 @@ Microsoft Fabric workspace. We will also add a data source to fetch the Microsof
     ```
 
 1. Create a file named notebook.ipynb in the same folder and copy the content of [this example notebook](https://github.com/Azure-Samples/modern-data-warehouse-dataops/blob/main/single_tech_samples/fabric/fabric_ci_cd/src/notebooks/nb-city-safety.ipynb).
-1. Create a file named `notebook.tf` and add the following hcl code to represent a notebook. This notebook references the workspace created in step 4, specifically using the workspace id.
+1. Create a file named `notebook.tf` and add the following hcl code to represent a Notebook. This Notebook references the workspace created in step 4, specifically using the workspace id.
 
     ```terraform
     resource "fabric_notebook" "example_notebook" {
@@ -116,7 +115,7 @@ Microsoft Fabric workspace. We will also add a data source to fetch the Microsof
     }
     ```
 
-1. Create another file named `terraform.tfvars`, and add the following code. This file specifies the notebook's properties. Learn more about [tfvars file](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files).
+1. Create another file named `terraform.tfvars`, and add the following code. This file specifies the Notebook's properties. Learn more about [tfvars file](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files).
 
     ```terraform
     workspace_display_name = "example workspace"
@@ -141,8 +140,8 @@ Microsoft Fabric workspace. We will also add a data source to fetch the Microsof
 1. Run `terraform init`. If there are any errors, fix them, and then run the command again.
 1. Run `terraform plan -out=plan.tfplan`. If there are any errors, fix them, and then run the command again. In this example, we are capturing the output to a plan file named `plan.tfplan`.
 1. Run `terraform apply plan.tfplan`. This command applies the changes required to reach the desired state of the configuration. If there are any errors, fix them, and then run the command again.
-1. Verify that the workspace and notebook were created in Microsoft Fabric. In the output of the `terraform apply` command, find the notebook id and capacity id.
-1. when you are done with this sample, delete the notebook, and workspace from Microsoft Fabric by running `terraform destroy`.
+1. Verify that the Workspace and Notebook were created in Microsoft Fabric. In the output of the `terraform apply` command, find the Notebook id and capacity id.
+1. when you are done with this sample, delete the Notebook, and workspace from Microsoft Fabric by running `terraform destroy`.
 
 ## Troubleshooting
 

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -28,7 +28,9 @@ You then configure Terraform authentication. Following this section, this articl
     Include Terraform configurations for your project in one or more configuration files in your Terraform project. For information about the configuration file syntax, see [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) on the Terraform website.
 
 1. You must configure authentication for your Terraform project. See [Authentication](./auth_app_reg_spn.md) in the Microsoft Fabric Terraform Provider documentation.
-1. You must have a [Fabric Capacity](https://learn.microsoft.com/fabric/enterprise/licenses#capacity) provisioned in Azure. A capacity can be added in the [Azure Portal](https://portal.azure.com/#browse/Microsoft.Fabric%2Fcapacities). Note: Please keep the capacity name handy, as we will use it below to fetch the capacity id.
+1. You must have a [Fabric Capacity](https://learn.microsoft.com/fabric/enterprise/licenses#capacity) provisioned in Azure. See [Configuring a Fabric Capacity](./fabric_capacity_setup.md) in the Microsoft Fabric Terraform Provider documentation.
+
+-> Please keep the capacity name handy, as we will use it below to fetch the capacity id.
 
 ## Sample configuration
 

--- a/templates/guides/getting_started.md.tmpl
+++ b/templates/guides/getting_started.md.tmpl
@@ -7,13 +7,13 @@ description: |-
 
 # Getting started
 
-[HashiCorp Terraform](https://www.terraform.io/) is a popular open source tool for creating safe and predictable cloud infrastructure across several cloud providers.
+[HashiCorp Terraform](https://www.terraform.io/) is a popular open-source tool for creating safe and predictable cloud infrastructure across several cloud providers.
 You can use the Microsoft Fabric Terraform Provider to manage your Microsoft Fabric workspaces using a flexible, powerful tool.
 The goal of the Microsoft Fabric Terraform Provider is to support automation of the most complicated aspects of deploying and managing Microsoft Fabric.
 Microsoft Fabric customers are using the Microsoft Fabric Terraform Provider to deploy and manage clusters and jobs and to configure data access.
 
 In this section, you install and configure requirements to use Terraform and the Microsoft Fabric Terraform Provider on your local development machine.
-You then configure Terraform authentication. Following this section, this article provides a sample configuration that you can experiment with to provision a Microsoft Fabric notebook and lakehouse.
+You then configure Terraform authentication. Following this section, this article provides a sample configuration that you can experiment with to provision a Microsoft Fabric Notebook and Lakehouse.
 
 ## Requirements
 
@@ -28,18 +28,36 @@ You then configure Terraform authentication. Following this section, this articl
     Include Terraform configurations for your project in one or more configuration files in your Terraform project. For information about the configuration file syntax, see [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) on the Terraform website.
 
 1. You must configure authentication for your Terraform project. See [Authentication](./auth_app_reg_spn.md) in the Microsoft Fabric Terraform Provider documentation.
-1. You must have a [Fabric Capacity](https://learn.microsoft.com/fabric/enterprise/licenses#capacity) provisioned in Azure. A capacity can be added in the [Azure Portal](https://portal.azure.com/#browse/Microsoft.Fabric%2Fcapacities). Note: Please keep the capacity name handy, as we will use it below to fetch the capacity id.
+1. You must have a [Fabric Capacity](https://learn.microsoft.com/fabric/enterprise/licenses#capacity) provisioned in Azure. See [Configuring a Fabric Capacity](./fabric_capacity_setup.md) in the Microsoft Fabric Terraform Provider documentation.
+
+-> Please keep the capacity name handy, as we will use it below to fetch the capacity id.
 
 ## Sample configuration
 
-This section provides a sample configuration that you can experiment with to provision a Microsoft Fabric notebook and a lakehouse. It assumes that you have already set up the requirements, as well as created a Terraform project and configured the project with Terraform authentication as described in the previous section.
+This section provides a sample configuration that you can experiment with to provision a Microsoft Fabric Notebook and a Lakehouse. It assumes that you have already set up the requirements, as well as created a Terraform project and configured the project with Terraform authentication as described in the previous section.
 
 1. Create a new file named `provider.tf` in your Terraform project directory.
 1. Add the following code to `provider.tf` to define a dependency on the Microsoft Fabric Terraform Provider:
 
-{{ tffile "examples/provider/provider.tf" }}
+    ```terraform
+    # We strongly recommend using the required_providers block to set the Fabric Provider source and version being used
+    terraform {
+      required_version = ">= 1.8, < 2.0"
+      required_providers {
+        fabric = {
+          source  = "microsoft/fabric"
+          version = "0.1.0-beta.6"
+        }
+      }
+    }
 
-1. Create another file named `variables.tf`, and add the following code. This file represents input variables that can be used to configure a notebook and lakehouse.
+    # Configure the Microsoft Fabric Terraform Provider
+    provider "fabric" {
+      # Configuration options
+    }
+    ```
+
+1. Create another file named `variables.tf`, and add the following code. This file represents input variables that can be used to configure a Notebook and Lakehouse.
 
     ```terraform
     variable "workspace_display_name" {
@@ -69,8 +87,7 @@ This section provides a sample configuration that you can experiment with to pro
     }
     ```
 
-1. Create a file named `workspace.tf` and add the following hcl code to represent a
-Microsoft Fabric workspace. We will also add a data source to fetch the Microsoft Fabric Capacity id by name (see requirements section).
+1. Create a file named `workspace.tf` and add the following hcl code to represent a Microsoft Fabric workspace. We will also add a data source to fetch the Microsoft Fabric Capacity id by name (see requirements section).
 
     ```terraform
     data "fabric_capacity" "capacity" {
@@ -85,7 +102,7 @@ Microsoft Fabric workspace. We will also add a data source to fetch the Microsof
     ```
 
 1. Create a file named notebook.ipynb in the same folder and copy the content of [this example notebook](https://github.com/Azure-Samples/modern-data-warehouse-dataops/blob/main/single_tech_samples/fabric/fabric_ci_cd/src/notebooks/nb-city-safety.ipynb).
-1. Create a file named `notebook.tf` and add the following hcl code to represent a notebook. This notebook references the workspace created in step 4, specifically using the workspace id.
+1. Create a file named `notebook.tf` and add the following hcl code to represent a Notebook. This Notebook references the workspace created in step 4, specifically using the workspace id.
 
     ```terraform
     resource "fabric_notebook" "example_notebook" {
@@ -100,7 +117,7 @@ Microsoft Fabric workspace. We will also add a data source to fetch the Microsof
     }
     ```
 
-1. Create another file named `terraform.tfvars`, and add the following code. This file specifies the notebook's properties. Learn more about [tfvars file](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files).
+1. Create another file named `terraform.tfvars`, and add the following code. This file specifies the Notebook's properties. Learn more about [tfvars file](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files).
 
     ```terraform
     workspace_display_name = "example workspace"
@@ -125,8 +142,8 @@ Microsoft Fabric workspace. We will also add a data source to fetch the Microsof
 1. Run `terraform init`. If there are any errors, fix them, and then run the command again.
 1. Run `terraform plan -out=plan.tfplan`. If there are any errors, fix them, and then run the command again. In this example, we are capturing the output to a plan file named `plan.tfplan`.
 1. Run `terraform apply plan.tfplan`. This command applies the changes required to reach the desired state of the configuration. If there are any errors, fix them, and then run the command again.
-1. Verify that the workspace and notebook were created in Microsoft Fabric. In the output of the `terraform apply` command, find the notebook id and capacity id.
-1. when you are done with this sample, delete the notebook, and workspace from Microsoft Fabric by running `terraform destroy`.
+1. Verify that the Workspace and Notebook were created in Microsoft Fabric. In the output of the `terraform apply` command, find the Notebook id and capacity id.
+1. when you are done with this sample, delete the Notebook, and workspace from Microsoft Fabric by running `terraform destroy`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the `getting_started.md` guide and its template to improve clarity and consistency, as well as a minor change to the `.changie.yaml` configuration file.

## ✨ Description of new changes

Improvements to documentation:

* `docs/guides/getting_started.md` and `templates/guides/getting_started.md.tmpl`: Corrected terminology to use "Notebook" and "Lakehouse" consistently with proper capitalization. [[1]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L10-R16) [[2]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L31-R37) [[3]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L58-R60) [[4]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L88-R90) [[5]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L104-R105) [[6]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L119-R120) [[7]](diffhunk://#diff-475d3e393e0447deccac73a32a7ec81e02abb8eb3d38a9ddf6ae14ff5f1e71c7L144-R146)
* `docs/guides/getting_started.md` and `templates/guides/getting_started.md.tmpl`: Updated the section on configuring a Fabric Capacity to include a link to the relevant documentation.

Configuration updates:

* [`.changie.yaml`](diffhunk://#diff-9f1c8d07b49e66598bb525c145a5d7524fef447d6993b72ccb378e70ebf922f3R49-R51): Added a new replacement rule for the `getting_started.md.tmpl` template to ensure the correct version format is used.
