### PR TITLE
refactor(fabitem): simplify schema and remove redundant code

### DIFF
--- a/internal/pkg/fabricitem/data_item.go
+++ b/internal/pkg/fabricitem/data_item.go
@@ -45,7 +45,7 @@ func (d *DataSourceFabricItem) Metadata(_ context.Context, req datasource.Metada
 }
 
 func (d *DataSourceFabricItem) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = GetDataSourceFabricItemSchema(ctx, d.Name, d.MarkdownDescription, d.IsDisplayNameUnique)
+	resp.Schema = GetDataSourceFabricItemSchema(ctx, *d)
 }
 
 func (d *DataSourceFabricItem) ConfigValidators(_ context.Context) []datasource.ConfigValidator {

--- a/internal/pkg/fabricitem/data_item_definition.go
+++ b/internal/pkg/fabricitem/data_item_definition.go
@@ -49,7 +49,7 @@ func (d *DataSourceFabricItemDefinition) Metadata(_ context.Context, req datasou
 }
 
 func (d *DataSourceFabricItemDefinition) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = GetDataSourceFabricItemDefinitionSchema(ctx, d.Name, d.MarkdownDescription, d.IsDisplayNameUnique, d.FormatTypes, d.DefinitionPathKeys)
+	resp.Schema = GetDataSourceFabricItemDefinitionSchema(ctx, *d)
 }
 
 func (d *DataSourceFabricItemDefinition) ConfigValidators(_ context.Context) []datasource.ConfigValidator {

--- a/internal/pkg/fabricitem/data_schema.go
+++ b/internal/pkg/fabricitem/data_schema.go
@@ -15,76 +15,54 @@ import (
 	"github.com/microsoft/terraform-provider-fabric/internal/pkg/utils"
 )
 
-func GetDataSourceFabricItemSchema(ctx context.Context, itemName, markdownDescription string, isDisplayNameUnique bool) schema.Schema {
-	attributes := baseDataSourceFabricItemAttributes(ctx, itemName, isDisplayNameUnique)
+func GetDataSourceFabricItemSchema(ctx context.Context, d DataSourceFabricItem) schema.Schema {
+	attributes := getDataSourceFabricItemBaseAttributes(ctx, d.Name, d.IsDisplayNameUnique)
 
 	return schema.Schema{
-		MarkdownDescription: markdownDescription,
+		MarkdownDescription: d.MarkdownDescription,
 		Attributes:          attributes,
 	}
 }
 
-func GetDataSourceFabricItemDefinitionSchema(ctx context.Context, itemName, markdownDescription string, isDisplayNameUnique bool, formatTypes, possibleKeys []string) schema.Schema {
-	attributes := baseDataSourceFabricItemAttributes(ctx, itemName, isDisplayNameUnique)
+func GetDataSourceFabricItemDefinitionSchema(ctx context.Context, d DataSourceFabricItemDefinition) schema.Schema {
+	attributes := getDataSourceFabricItemBaseAttributes(ctx, d.Name, d.IsDisplayNameUnique)
 
-	if len(formatTypes) > 0 {
-		attributes["format"] = schema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("The %s format. Possible values: %s.", itemName, utils.ConvertStringSlicesToString(formatTypes, true, false)),
-			Computed:            true,
-		}
-	} else {
-		attributes["format"] = schema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("The %s format. Possible values: `%s`", itemName, DefinitionFormatNotApplicable),
-			Computed:            true,
-		}
-	}
-
-	attributes["output_definition"] = schema.BoolAttribute{
-		MarkdownDescription: "Output definition parts as gzip base64 content? Default: `false`\n\n" +
-			"!> Your terraform state file may grow a lot if you output definition content. Only use it when you must use data from the definition.",
-		Optional: true,
-		Computed: true,
-	}
-
-	definitionMarkdownDescription := "Definition parts."
-
-	if len(possibleKeys) > 0 {
-		definitionMarkdownDescription = definitionMarkdownDescription + " Possible path keys: " + utils.ConvertStringSlicesToString(possibleKeys, true, false) + "."
-	}
-
-	attributes["definition"] = schema.MapNestedAttribute{
-		MarkdownDescription: definitionMarkdownDescription,
-		Computed:            true,
-		CustomType:          supertypes.NewMapNestedObjectTypeOf[DataSourceFabricItemDefinitionPartModel](ctx),
-		NestedObject: schema.NestedAttributeObject{
-			Attributes: map[string]schema.Attribute{
-				"content": schema.StringAttribute{
-					MarkdownDescription: "Gzip base64 content of definition part.\n" +
-						"Use [`provider::fabric::content_decode`](../functions/content_decode.md) function to decode content.",
-					Computed: true,
-				},
-			},
-		},
+	for key, value := range getDataSourceFabricItemDefinitionAttributes(ctx, d) {
+		attributes[key] = value
 	}
 
 	return schema.Schema{
-		MarkdownDescription: markdownDescription,
+		MarkdownDescription: d.MarkdownDescription,
 		Attributes:          attributes,
 	}
 }
 
-func GetDataSourceFabricItemPropertiesSchema(ctx context.Context, itemName, markdownDescription string, isDisplayNameUnique bool, properties schema.SingleNestedAttribute) schema.Schema {
-	attributes := baseDataSourceFabricItemAttributes(ctx, itemName, isDisplayNameUnique)
+func GetDataSourceFabricItemPropertiesSchema(ctx context.Context, d DataSourceFabricItem, properties schema.SingleNestedAttribute) schema.Schema {
+	attributes := getDataSourceFabricItemBaseAttributes(ctx, d.Name, d.IsDisplayNameUnique)
 	attributes["properties"] = properties
 
 	return schema.Schema{
-		MarkdownDescription: markdownDescription,
+		MarkdownDescription: d.MarkdownDescription,
+		Attributes:          attributes,
+	}
+}
+
+func GetDataSourceFabricItemPropertiesDefinitionSchema(ctx context.Context, d DataSourceFabricItemDefinition, properties schema.SingleNestedAttribute) schema.Schema {
+	attributes := getDataSourceFabricItemBaseAttributes(ctx, d.Name, d.IsDisplayNameUnique)
+	attributes["properties"] = properties
+
+	for key, value := range getDataSourceFabricItemDefinitionAttributes(ctx, d) {
+		attributes[key] = value
+	}
+
+	return schema.Schema{
+		MarkdownDescription: d.MarkdownDescription,
 		Attributes:          attributes,
 	}
 }
 
 // Helper function to get base Fabric Item data-source attributes.
-func baseDataSourceFabricItemAttributes(ctx context.Context, itemName string, isDisplayNameUnique bool) map[string]schema.Attribute { //revive:disable-line:flag-parameter
+func getDataSourceFabricItemBaseAttributes(ctx context.Context, itemName string, isDisplayNameUnique bool) map[string]schema.Attribute { //revive:disable-line:flag-parameter
 	attributes := map[string]schema.Attribute{
 		"workspace_id": schema.StringAttribute{
 			MarkdownDescription: "The Workspace ID.",
@@ -120,6 +98,53 @@ func baseDataSourceFabricItemAttributes(ctx context.Context, itemName string, is
 			MarkdownDescription: fmt.Sprintf("The %s display name.", itemName),
 			Computed:            true,
 		}
+	}
+
+	return attributes
+}
+
+// Helper function to get Fabric Item data-source definition attributes.
+func getDataSourceFabricItemDefinitionAttributes(ctx context.Context, d DataSourceFabricItemDefinition) map[string]schema.Attribute {
+	attributes := make(map[string]schema.Attribute)
+
+	if len(d.FormatTypes) > 0 {
+		attributes["format"] = schema.StringAttribute{
+			MarkdownDescription: fmt.Sprintf("The %s format. Possible values: %s.", d.Name, utils.ConvertStringSlicesToString(d.FormatTypes, true, false)),
+			Computed:            true,
+		}
+	} else {
+		attributes["format"] = schema.StringAttribute{
+			MarkdownDescription: fmt.Sprintf("The %s format. Possible values: `%s`", d.Name, DefinitionFormatNotApplicable),
+			Computed:            true,
+		}
+	}
+
+	attributes["output_definition"] = schema.BoolAttribute{
+		MarkdownDescription: "Output definition parts as gzip base64 content? Default: `false`\n\n" +
+			"!> Your terraform state file may grow a lot if you output definition content. Only use it when you must use data from the definition.",
+		Optional: true,
+		Computed: true,
+	}
+
+	definitionMarkdownDescription := "Definition parts."
+
+	if len(d.DefinitionPathKeys) > 0 {
+		definitionMarkdownDescription = definitionMarkdownDescription + " Possible path keys: " + utils.ConvertStringSlicesToString(d.DefinitionPathKeys, true, false) + "."
+	}
+
+	attributes["definition"] = schema.MapNestedAttribute{
+		MarkdownDescription: definitionMarkdownDescription,
+		Computed:            true,
+		CustomType:          supertypes.NewMapNestedObjectTypeOf[DataSourceFabricItemDefinitionPartModel](ctx),
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"content": schema.StringAttribute{
+					MarkdownDescription: "Gzip base64 content of definition part.\n" +
+						"Use [`provider::fabric::content_decode`](../functions/content_decode.md) function to decode content.",
+					Computed: true,
+				},
+			},
+		},
 	}
 
 	return attributes

--- a/internal/pkg/fabricitem/resource_item.go
+++ b/internal/pkg/fabricitem/resource_item.go
@@ -9,15 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	fabcore "github.com/microsoft/fabric-sdk-go/fabric/core"
 
@@ -54,53 +48,7 @@ func (r *ResourceFabricItem) Metadata(_ context.Context, req resource.MetadataRe
 }
 
 func (r *ResourceFabricItem) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	displayNamePlanModifiers := []planmodifier.String{}
-
-	if !r.NameRenameAllowed {
-		displayNamePlanModifiers = []planmodifier.String{
-			stringplanmodifier.RequiresReplace(),
-		}
-	}
-
-	resp.Schema = schema.Schema{
-		MarkdownDescription: r.MarkdownDescription,
-		Attributes: map[string]schema.Attribute{
-			"workspace_id": schema.StringAttribute{
-				MarkdownDescription: "The Workspace ID.",
-				Required:            true,
-				CustomType:          customtypes.UUIDType{},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"id": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The %s ID.", r.Name),
-				Computed:            true,
-				CustomType:          customtypes.UUIDType{},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"display_name": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The %s display name.", r.Name),
-				Required:            true,
-				Validators: []validator.String{
-					stringvalidator.LengthAtMost(r.DisplayNameMaxLength),
-				},
-				PlanModifiers: displayNamePlanModifiers,
-			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The %s description.", r.Name),
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString(""),
-				Validators: []validator.String{
-					stringvalidator.LengthAtMost(r.DescriptionMaxLength),
-				},
-			},
-			"timeouts": timeouts.AttributesAll(ctx),
-		},
-	}
+	resp.Schema = GetResourceFabricItemSchema(ctx, *r)
 }
 
 func (r *ResourceFabricItem) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/services/environment/data_environment.go
+++ b/internal/services/environment/data_environment.go
@@ -113,7 +113,15 @@ func (d *dataSourceEnvironment) Schema(ctx context.Context, _ datasource.SchemaR
 		},
 	}
 
-	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, ItemName, markdownDescription, true, properties)
+	itemConfig := fabricitem.DataSourceFabricItem{
+		Type:                ItemType,
+		Name:                ItemName,
+		TFName:              ItemTFName,
+		MarkdownDescription: markdownDescription,
+		IsDisplayNameUnique: true,
+	}
+
+	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, itemConfig, properties)
 }
 
 func (d *dataSourceEnvironment) ConfigValidators(_ context.Context) []datasource.ConfigValidator {

--- a/internal/services/eventhouse/data_eventhouse.go
+++ b/internal/services/eventhouse/data_eventhouse.go
@@ -67,7 +67,15 @@ func (d *dataSourceEventhouse) Schema(ctx context.Context, _ datasource.SchemaRe
 		},
 	}
 
-	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, ItemName, markdownDescription, true, properties)
+	itemConfig := fabricitem.DataSourceFabricItem{
+		Type:                ItemType,
+		Name:                ItemName,
+		TFName:              ItemTFName,
+		MarkdownDescription: markdownDescription,
+		IsDisplayNameUnique: true,
+	}
+
+	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, itemConfig, properties)
 }
 
 func (d *dataSourceEventhouse) ConfigValidators(_ context.Context) []datasource.ConfigValidator {

--- a/internal/services/kqldatabase/data_kql_database.go
+++ b/internal/services/kqldatabase/data_kql_database.go
@@ -74,7 +74,15 @@ func (d *dataSourceKQLDatabase) Schema(ctx context.Context, _ datasource.SchemaR
 		},
 	}
 
-	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, ItemName, markdownDescription, true, properties)
+	itemConfig := fabricitem.DataSourceFabricItem{
+		Type:                ItemType,
+		Name:                ItemName,
+		TFName:              ItemTFName,
+		MarkdownDescription: markdownDescription,
+		IsDisplayNameUnique: true,
+	}
+
+	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, itemConfig, properties)
 }
 
 func (d *dataSourceKQLDatabase) ConfigValidators(_ context.Context) []datasource.ConfigValidator {

--- a/internal/services/lakehouse/data_lakehouse.go
+++ b/internal/services/lakehouse/data_lakehouse.go
@@ -87,7 +87,15 @@ func (d *dataSourceLakehouse) Schema(ctx context.Context, _ datasource.SchemaReq
 		},
 	}
 
-	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, ItemName, markdownDescription, true, properties)
+	itemConfig := fabricitem.DataSourceFabricItem{
+		Type:                ItemType,
+		Name:                ItemName,
+		TFName:              ItemTFName,
+		MarkdownDescription: markdownDescription,
+		IsDisplayNameUnique: true,
+	}
+
+	resp.Schema = fabricitem.GetDataSourceFabricItemPropertiesSchema(ctx, itemConfig, properties)
 }
 
 func (d *dataSourceLakehouse) ConfigValidators(_ context.Context) []datasource.ConfigValidator {

--- a/internal/services/lakehouse/resource_lakehouse.go
+++ b/internal/services/lakehouse/resource_lakehouse.go
@@ -92,6 +92,7 @@ func (r *resourceLakehouse) Schema(ctx context.Context, _ resource.SchemaRequest
 			},
 		},
 	}
+
 	configuration := schema.SingleNestedAttribute{
 		MarkdownDescription: "The " + ItemName + " creation configuration.\n\n" +
 			"Any changes to this configuration will result in recreation of the " + ItemName + ".",


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several changes to the `internal/pkg/fabricitem` package to refactor the schema generation functions for better consistency and maintainability. The changes involve modifying the way schema attributes are passed and organized and removing redundant code.

## ✨ Description of new changes

### Schema Refactoring:

* [`internal/pkg/fabricitem/data_item.go`](diffhunk://#diff-78ca03c11129aabf8542b34344736e45023c0524c94f46188e31b993815534acL48-R48): Updated the `Schema` method in `DataSourceFabricItem` to pass the entire `DataSourceFabricItem` struct instead of individual attributes.
* [`internal/pkg/fabricitem/data_item_definition.go`](diffhunk://#diff-380ac3fbb146117b87b0fc813d1167045947ed19b7d8098fdcbaae5ef28db6aeL52-R52): Updated the `Schema` method in `DataSourceFabricItemDefinition` to pass the entire `DataSourceFabricItemDefinition` struct instead of individual attributes.
* [`internal/pkg/fabricitem/data_schema.go`](diffhunk://#diff-fe043662a302496eff6843571393d1225ec3d0d9685fe673d3364f3414928e38L18-R65): Refactored schema generation functions to accept structs (`DataSourceFabricItem` and `DataSourceFabricItemDefinition`) and added a helper function to get definition attributes. [[1]](diffhunk://#diff-fe043662a302496eff6843571393d1225ec3d0d9685fe673d3364f3414928e38L18-R65) [[2]](diffhunk://#diff-fe043662a302496eff6843571393d1225ec3d0d9685fe673d3364f3414928e38R105-R151)

### Resource Schema Simplification:

* [`internal/pkg/fabricitem/resource_item.go`](diffhunk://#diff-e5edf4ef7b865390de37aefee630d636c80875eb2e289a5dc6070a5ae3b1ef7bL57-R51): Updated the `Schema` method in `ResourceFabricItem` to use the new `GetResourceFabricItemSchema` function. Removed redundant attribute definitions.
* [`internal/pkg/fabricitem/resource_item_definition.go`](diffhunk://#diff-948963c6ade2937fb967fd6edaca23823a78c73a3a155726402c25f36238bcf8L109-R103): Updated the `Schema` method in `ResourceFabricItemDefinition` to use the new `GetResourceFabricItemDefinitionSchema` function. Removed redundant attribute definitions.

### Import Cleanup:

* Removed unused imports from `internal/pkg/fabricitem/resource_item.go` and `internal/pkg/fabricitem/resource_item_definition.go`. [[1]](diffhunk://#diff-e5edf4ef7b865390de37aefee630d636c80875eb2e289a5dc6070a5ae3b1ef7bL12-L20) [[2]](diffhunk://#diff-948963c6ade2937fb967fd6edaca23823a78c73a3a155726402c25f36238bcf8L14-L22)