### PR TITLE
fix(provider): update appid format in telemetry

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -114,7 +114,7 @@ func createDefaultClient(ctx context.Context, cfg *pconfig.ProviderConfig) (*fab
 
 	// ApplicationID is an application-specific identification string to add to the User-Agent.
 	// It has a maximum length of 24 characters and must not contain any spaces.
-	fabricClientOpt.Telemetry.ApplicationID = "tfprov-fabric/" + cfg.Version
+	fabricClientOpt.Telemetry.ApplicationID = "tffab/" + cfg.Version
 	fabricClientOpt.Telemetry.Disabled = false
 
 	// MaxRetries specifies the maximum number of attempts a failed operation will be retried before producing an error.


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request modifies the `internal/provider/provider.go` file to update the application-specific identification string used in telemetry.

## ✨ Description of new changes

* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L117-R117): Changed the `ApplicationID` from "tfprov-fabric/" to "tffab/" to shorten and simplify the identification string used in telemetry.
