### PR TITLE
fix: add missing diags

### DIFF
--- a/internal/services/domain/resource_domain_role_assignments.go
+++ b/internal/services/domain/resource_domain_role_assignments.go
@@ -314,7 +314,9 @@ func (r *resourceDomainRoleAssignments) Delete(ctx context.Context, req resource
 
 	var reqDelete requestDeleteDomainRoleAssignments
 
-	reqDelete.set(ctx, state)
+	if resp.Diagnostics.Append(reqDelete.set(ctx, state)...); resp.Diagnostics.HasError() {
+		return
+	}
 
 	_, err := r.client.RoleAssignmentsBulkUnassign(ctx, state.DomainID.ValueString(), reqDelete.DomainRoleUnassignmentRequest, nil)
 	if resp.Diagnostics.Append(utils.GetDiagsFromError(ctx, err, utils.OperationDelete, nil)...); resp.Diagnostics.HasError() {

--- a/internal/services/domain/resource_domain_workspace_assignments.go
+++ b/internal/services/domain/resource_domain_workspace_assignments.go
@@ -287,7 +287,9 @@ func (r *resourceDomainWorkspaceAssignments) Delete(ctx context.Context, req res
 	if len(state.WorkspaceIDs.Elements()) > 0 {
 		var reqDelete requestDeleteDomainWorkspaceAssignments
 
-		reqDelete.set(ctx, state)
+		if resp.Diagnostics.Append(reqDelete.set(ctx, state)...); resp.Diagnostics.HasError() {
+			return
+		}
 
 		_, err := r.client.UnassignDomainWorkspacesByIDs(ctx, state.DomainID.ValueString(), &fabadmin.DomainsClientUnassignDomainWorkspacesByIDsOptions{
 			UnassignDomainWorkspacesByIDsRequest: &reqDelete.UnassignDomainWorkspacesByIDsRequest,

--- a/internal/services/environment/data_environment.go
+++ b/internal/services/environment/data_environment.go
@@ -208,9 +208,8 @@ func (d *dataSourceEnvironment) getByID(ctx context.Context, model *dataSourceEn
 	}
 
 	model.set(respGet.Environment)
-	model.setProperties(ctx, respGet.Environment)
 
-	return nil
+	return model.setProperties(ctx, respGet.Environment)
 }
 
 func (d *dataSourceEnvironment) getByDisplayName(ctx context.Context, model *dataSourceEnvironmentModel) diag.Diagnostics {
@@ -228,9 +227,8 @@ func (d *dataSourceEnvironment) getByDisplayName(ctx context.Context, model *dat
 		for _, entity := range page.Value {
 			if *entity.DisplayName == model.DisplayName.ValueString() {
 				model.set(entity)
-				model.setProperties(ctx, entity)
 
-				return nil
+				return model.setProperties(ctx, entity)
 			}
 		}
 	}

--- a/internal/services/environment/models.go
+++ b/internal/services/environment/models.go
@@ -39,7 +39,10 @@ func (to *baseEnvironmentPropertiesModel) setProperties(ctx context.Context, fro
 
 	if from.Properties != nil {
 		propertiesModel := &environmentPropertiesModel{}
-		propertiesModel.set(ctx, from.Properties)
+
+		if diags := propertiesModel.set(ctx, from.Properties); diags.HasError() {
+			return diags
+		}
 
 		if diags := properties.Set(ctx, propertiesModel); diags.HasError() {
 			return diags
@@ -55,16 +58,24 @@ type environmentPropertiesModel struct {
 	PublishDetails supertypes.SingleNestedObjectValueOf[environmentPublishDetailsModel] `tfsdk:"publish_details"`
 }
 
-func (to *environmentPropertiesModel) set(ctx context.Context, from *fabenvironment.PublishInfo) {
+func (to *environmentPropertiesModel) set(ctx context.Context, from *fabenvironment.PublishInfo) diag.Diagnostics {
 	publishDetails := supertypes.NewSingleNestedObjectValueOfNull[environmentPublishDetailsModel](ctx)
 
 	if from.PublishDetails != nil {
 		publishDetailsModel := &environmentPublishDetailsModel{}
-		publishDetailsModel.set(ctx, from.PublishDetails)
-		publishDetails.Set(ctx, publishDetailsModel)
+
+		if diags := publishDetailsModel.set(ctx, from.PublishDetails); diags.HasError() {
+			return diags
+		}
+
+		if diags := publishDetails.Set(ctx, publishDetailsModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.PublishDetails = publishDetails
+
+	return nil
 }
 
 type environmentPublishDetailsModel struct {
@@ -75,7 +86,7 @@ type environmentPublishDetailsModel struct {
 	ComponentPublishInfo supertypes.SingleNestedObjectValueOf[environmentComponentPublishInfoModel] `tfsdk:"component_publish_info"`
 }
 
-func (to *environmentPublishDetailsModel) set(ctx context.Context, from *fabenvironment.PublishDetails) {
+func (to *environmentPublishDetailsModel) set(ctx context.Context, from *fabenvironment.PublishDetails) diag.Diagnostics {
 	to.State = types.StringPointerValue((*string)(from.State))
 	to.TargetVersion = customtypes.NewUUIDPointerValue(from.TargetVersion)
 	to.StartTime = timetypes.NewRFC3339TimePointerValue(from.StartTime)
@@ -85,11 +96,19 @@ func (to *environmentPublishDetailsModel) set(ctx context.Context, from *fabenvi
 
 	if from.ComponentPublishInfo != nil {
 		publishDetailsModel := &environmentComponentPublishInfoModel{}
-		publishDetailsModel.set(ctx, from.ComponentPublishInfo)
-		componentPublishInfo.Set(ctx, publishDetailsModel)
+
+		if diags := publishDetailsModel.set(ctx, from.ComponentPublishInfo); diags.HasError() {
+			return diags
+		}
+
+		if diags := componentPublishInfo.Set(ctx, publishDetailsModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.ComponentPublishInfo = componentPublishInfo
+
+	return nil
 }
 
 type environmentComponentPublishInfoModel struct {
@@ -97,13 +116,16 @@ type environmentComponentPublishInfoModel struct {
 	SparkSettings  supertypes.SingleNestedObjectValueOf[environmentSparkSettingsModel]  `tfsdk:"spark_settings"`
 }
 
-func (to *environmentComponentPublishInfoModel) set(ctx context.Context, from *fabenvironment.ComponentPublishInfo) {
+func (to *environmentComponentPublishInfoModel) set(ctx context.Context, from *fabenvironment.ComponentPublishInfo) diag.Diagnostics {
 	sparkLibraries := supertypes.NewSingleNestedObjectValueOfNull[environmentSparkLibrariesModel](ctx)
 
 	if from.SparkLibraries != nil {
 		sparkLibrariesModel := &environmentSparkLibrariesModel{}
 		sparkLibrariesModel.set(from.SparkLibraries)
-		sparkLibraries.Set(ctx, sparkLibrariesModel)
+
+		if diags := sparkLibraries.Set(ctx, sparkLibrariesModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.SparkLibraries = sparkLibraries
@@ -113,10 +135,15 @@ func (to *environmentComponentPublishInfoModel) set(ctx context.Context, from *f
 	if from.SparkSettings != nil {
 		sparkSettingsModel := &environmentSparkSettingsModel{}
 		sparkSettingsModel.set(from.SparkSettings)
-		sparkSettings.Set(ctx, sparkSettingsModel)
+
+		if diags := sparkSettings.Set(ctx, sparkSettingsModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.SparkSettings = sparkSettings
+
+	return nil
 }
 
 type environmentSparkLibrariesModel struct {

--- a/internal/services/warehouse/data_warehouse.go
+++ b/internal/services/warehouse/data_warehouse.go
@@ -179,9 +179,7 @@ func (d *dataSourceWarehouse) getByID(ctx context.Context, model *dataSourceWare
 		return diags
 	}
 
-	model.set(ctx, respGet.Warehouse)
-
-	return nil
+	return model.set(ctx, respGet.Warehouse)
 }
 
 func (d *dataSourceWarehouse) getByDisplayName(ctx context.Context, model *dataSourceWarehouseModel) diag.Diagnostics {
@@ -198,9 +196,7 @@ func (d *dataSourceWarehouse) getByDisplayName(ctx context.Context, model *dataS
 
 		for _, entity := range page.Value {
 			if *entity.DisplayName == model.DisplayName.ValueString() {
-				model.set(ctx, entity)
-
-				return nil
+				return model.set(ctx, entity)
 			}
 		}
 	}

--- a/internal/services/warehouse/models.go
+++ b/internal/services/warehouse/models.go
@@ -8,6 +8,7 @@ import (
 
 	supertypes "github.com/FrangipaneTeam/terraform-plugin-framework-supertypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	fabwarehouse "github.com/microsoft/fabric-sdk-go/fabric/warehouse"
 
@@ -22,7 +23,7 @@ type baseWarehouseModel struct {
 	Properties  supertypes.SingleNestedObjectValueOf[warehousePropertiesModel] `tfsdk:"properties"`
 }
 
-func (to *baseWarehouseModel) set(ctx context.Context, from fabwarehouse.Warehouse) {
+func (to *baseWarehouseModel) set(ctx context.Context, from fabwarehouse.Warehouse) diag.Diagnostics {
 	to.WorkspaceID = customtypes.NewUUIDPointerValue(from.WorkspaceID)
 	to.ID = customtypes.NewUUIDPointerValue(from.ID)
 	to.DisplayName = types.StringPointerValue(from.DisplayName)
@@ -33,10 +34,15 @@ func (to *baseWarehouseModel) set(ctx context.Context, from fabwarehouse.Warehou
 	if from.Properties != nil {
 		propertiesModel := &warehousePropertiesModel{}
 		propertiesModel.set(from.Properties)
-		properties.Set(ctx, propertiesModel)
+
+		if diags := properties.Set(ctx, propertiesModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.Properties = properties
+
+	return nil
 }
 
 type warehousePropertiesModel struct {

--- a/internal/services/warehouse/resource_warehouse.go
+++ b/internal/services/warehouse/resource_warehouse.go
@@ -215,7 +215,6 @@ func (r *resourceWarehouse) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.Append(diags...)
 
 		return
-
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -376,7 +375,7 @@ func (r *resourceWarehouse) ImportState(ctx context.Context, req resource.Import
 func (r *resourceWarehouse) get(ctx context.Context, model *resourceWarehouseModel, operation utils.Operation) diag.Diagnostics {
 	tflog.Trace(ctx, "getting Warehouse")
 
-	var errIs error = nil
+	var errIs error
 	if operation == utils.OperationRead {
 		errIs = fabcore.ErrCommon.EntityNotFound
 	}

--- a/internal/services/warehouse/resource_warehouse.go
+++ b/internal/services/warehouse/resource_warehouse.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -163,12 +164,13 @@ func (r *resourceWarehouse) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	plan.set(ctx, respCreate.Warehouse)
+	if resp.Diagnostics.Append(plan.set(ctx, respCreate.Warehouse)...); resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 
-	err = r.get(ctx, &plan)
-	if resp.Diagnostics.Append(utils.GetDiagsFromError(ctx, err, utils.OperationCreate, nil)...); resp.Diagnostics.HasError() {
+	if resp.Diagnostics.Append(r.get(ctx, &plan, utils.OperationCreate)...); resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -205,8 +207,7 @@ func (r *resourceWarehouse) Read(ctx context.Context, req resource.ReadRequest, 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	err := r.get(ctx, &state)
-	if diags := utils.GetDiagsFromError(ctx, err, utils.OperationRead, fabcore.ErrCommon.EntityNotFound); diags.HasError() {
+	if diags := r.get(ctx, &state, utils.OperationRead); diags.HasError() {
 		if utils.IsErrNotFound(state.ID.ValueString(), &diags, fabcore.ErrCommon.EntityNotFound) {
 			resp.State.RemoveResource(ctx)
 		}
@@ -214,6 +215,7 @@ func (r *resourceWarehouse) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.Append(diags...)
 
 		return
+
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -260,12 +262,15 @@ func (r *resourceWarehouse) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	plan.set(ctx, respUpdate.Warehouse)
+	if resp.Diagnostics.Append(plan.set(ctx, respUpdate.Warehouse)...); resp.Diagnostics.HasError() {
+		return
+	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.Append(resp.State.Set(ctx, plan)...); resp.Diagnostics.HasError() {
+		return
+	}
 
-	err = r.get(ctx, &plan)
-	if resp.Diagnostics.Append(utils.GetDiagsFromError(ctx, err, utils.OperationUpdate, nil)...); resp.Diagnostics.HasError() {
+	if resp.Diagnostics.Append(r.get(ctx, &plan, utils.OperationUpdate)...); resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -353,8 +358,7 @@ func (r *resourceWarehouse) ImportState(ctx context.Context, req resource.Import
 		Timeouts: timeout,
 	}
 
-	err := r.get(ctx, &state)
-	if resp.Diagnostics.Append(utils.GetDiagsFromError(ctx, err, utils.OperationImport, nil)...); resp.Diagnostics.HasError() {
+	if resp.Diagnostics.Append(r.get(ctx, &state, utils.OperationImport)...); resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -369,15 +373,18 @@ func (r *resourceWarehouse) ImportState(ctx context.Context, req resource.Import
 	}
 }
 
-func (r *resourceWarehouse) get(ctx context.Context, model *resourceWarehouseModel) error {
+func (r *resourceWarehouse) get(ctx context.Context, model *resourceWarehouseModel, operation utils.Operation) diag.Diagnostics {
 	tflog.Trace(ctx, "getting Warehouse")
 
-	respGet, err := r.client.GetWarehouse(ctx, model.WorkspaceID.ValueString(), model.ID.ValueString(), nil)
-	if err != nil {
-		return err
+	var errIs error = nil
+	if operation == utils.OperationRead {
+		errIs = fabcore.ErrCommon.EntityNotFound
 	}
 
-	model.set(ctx, respGet.Warehouse)
+	respGet, err := r.client.GetWarehouse(ctx, model.WorkspaceID.ValueString(), model.ID.ValueString(), nil)
+	if diags := utils.GetDiagsFromError(ctx, err, operation, errIs); diags.HasError() {
+		return diags
+	}
 
-	return nil
+	return model.set(ctx, respGet.Warehouse)
 }

--- a/internal/services/workspace/data_workspace.go
+++ b/internal/services/workspace/data_workspace.go
@@ -216,9 +216,7 @@ func (d *dataSourceWorkspace) getByID(ctx context.Context, model *dataSourceWork
 		return diags
 	}
 
-	model.set(ctx, respGet.WorkspaceInfo)
-
-	return nil
+	return model.set(ctx, respGet.WorkspaceInfo)
 }
 
 func (d *dataSourceWorkspace) getByDisplayName(ctx context.Context, model *dataSourceWorkspaceModel) diag.Diagnostics {

--- a/internal/services/workspace/models.go
+++ b/internal/services/workspace/models.go
@@ -24,7 +24,7 @@ type baseWorkspaceInfoModel struct {
 	Identity                   supertypes.SingleNestedObjectValueOf[workspaceIdentityModel] `tfsdk:"identity"`
 }
 
-func (to *baseWorkspaceInfoModel) set(ctx context.Context, from fabcore.WorkspaceInfo) {
+func (to *baseWorkspaceInfoModel) set(ctx context.Context, from fabcore.WorkspaceInfo) diag.Diagnostics {
 	to.ID = customtypes.NewUUIDPointerValue(from.ID)
 	to.DisplayName = types.StringPointerValue(from.DisplayName)
 	to.Description = types.StringPointerValue(from.Description)
@@ -38,7 +38,10 @@ func (to *baseWorkspaceInfoModel) set(ctx context.Context, from fabcore.Workspac
 	if from.OneLakeEndpoints != nil {
 		oneLakeEndpointsModel := &oneLakeEndpointsModel{}
 		oneLakeEndpointsModel.set(from.OneLakeEndpoints)
-		oneLakeEndpoints.Set(ctx, oneLakeEndpointsModel)
+
+		if diags := oneLakeEndpoints.Set(ctx, oneLakeEndpointsModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.OneLakeEndpoints = oneLakeEndpoints
@@ -48,10 +51,15 @@ func (to *baseWorkspaceInfoModel) set(ctx context.Context, from fabcore.Workspac
 	if from.WorkspaceIdentity != nil {
 		workspaceIdentityModel := &workspaceIdentityModel{}
 		workspaceIdentityModel.set(from.WorkspaceIdentity)
-		workspaceIdentity.Set(ctx, workspaceIdentityModel)
+
+		if diags := workspaceIdentity.Set(ctx, workspaceIdentityModel); diags.HasError() {
+			return diags
+		}
 	}
 
 	to.Identity = workspaceIdentity
+
+	return nil
 }
 
 type baseWorkspaceModel struct {

--- a/internal/services/workspace/models_data_workspace_role_assignments.go
+++ b/internal/services/workspace/models_data_workspace_role_assignments.go
@@ -26,7 +26,11 @@ func (to *dataSourceWorkspaceRoleAssignmentsModel) setValues(ctx context.Context
 
 	for _, entity := range from {
 		var entityModel workspaceRoleAssignmentModel
-		entityModel.set(ctx, entity)
+
+		if diags := entityModel.set(ctx, entity); diags.HasError() {
+			return diags
+		}
+
 		slice = append(slice, &entityModel)
 	}
 
@@ -41,13 +45,18 @@ type workspaceRoleAssignmentModel struct {
 	Details     supertypes.SingleNestedObjectValueOf[principalDetailsModel] `tfsdk:"details"`
 }
 
-func (to *workspaceRoleAssignmentModel) set(ctx context.Context, from fabcore.WorkspaceRoleAssignment) {
+func (to *workspaceRoleAssignmentModel) set(ctx context.Context, from fabcore.WorkspaceRoleAssignment) diag.Diagnostics {
 	to.ID = customtypes.NewUUIDPointerValue(from.ID)
 	to.Role = types.StringPointerValue((*string)(from.Role))
 
 	detailsModel := &principalDetailsModel{}
 	detailsModel.set(from.Principal, to)
-	to.Details.Set(ctx, detailsModel)
+
+	if diags := to.Details.Set(ctx, detailsModel); diags.HasError() {
+		return diags
+	}
+
+	return nil
 }
 
 type principalDetailsModel struct {

--- a/internal/services/workspace/resource_workspace.go
+++ b/internal/services/workspace/resource_workspace.go
@@ -600,9 +600,7 @@ func (r *resourceWorkspace) get(ctx context.Context, model *resourceWorkspaceMod
 			return diags
 
 		case fabcore.CapacityAssignmentProgressCompleted:
-			model.set(ctx, respGet.WorkspaceInfo)
-
-			return nil
+			return model.set(ctx, respGet.WorkspaceInfo)
 		default:
 			tflog.Info(ctx, "Workspace capacity assignment in progress, waiting 30 seconds before retrying")
 			time.Sleep(30 * time.Second) // lintignore:R018


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request focuses on enhancing error handling by ensuring that diagnostic information is properly propagated and checked across various functions. The changes span multiple files and functions.

These changes collectively improve the robustness of the code by ensuring that errors are properly handled, and diagnostic information is propagated throughout the system.

## ✨ Description of new changes

### Error Handling Improvements:

* [`internal/services/domain/resource_domain_role_assignments.go`](diffhunk://#diff-b1d01fb021b90119118f9a17c373d190c58abbf643d178c48c2ad5f82228d701L317-R319): Updated the `Delete` function to append diagnostics and check for errors after setting the request.
* [`internal/services/domain/resource_domain_workspace_assignments.go`](diffhunk://#diff-24bfcf1e3d5ab7ecf9eedac02be1ab93ec11f69adad3a76a76475adba4733b13L290-R292): Modified the `Delete` function to append diagnostics and check for errors after setting the request.

### Diagnostic Propagation:

* [`internal/services/environment/models.go`](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeL58-R78): Updated several `set` methods to return diagnostics and check for errors within nested property assignments. [[1]](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeL58-R78) [[2]](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeL78-R89) [[3]](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeL88-R128) [[4]](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeL116-R146)
* [`internal/services/warehouse/models.go`](diffhunk://#diff-0aacd0215ae3cf337fa3398273f0894beeb7477304eadaf56cbcc35f8eb3beb7L25-R26): Changed the `set` method in `baseWarehouseModel` to return diagnostics and handle errors during property assignments. [[1]](diffhunk://#diff-0aacd0215ae3cf337fa3398273f0894beeb7477304eadaf56cbcc35f8eb3beb7L25-R26) [[2]](diffhunk://#diff-0aacd0215ae3cf337fa3398273f0894beeb7477304eadaf56cbcc35f8eb3beb7L36-R45)
* [`internal/services/warehouse/resource_warehouse.go`](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4L166-R173): Updated the `Create`, `Read`, `Update`, and `ImportState` functions to append diagnostics and check for errors after setting the state. [[1]](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4L166-R173) [[2]](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4L208-R218) [[3]](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4L263-R273) [[4]](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4L356-R361) [[5]](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4L372-R389)

### Code Simplification:

* [`internal/services/warehouse/data_warehouse.go`](diffhunk://#diff-4d6799a33b2a8c7d1cd4da5b58db03a456ed0a3a2f5256135a651909255f7380L182-R182): Simplified the `getByID` and `getByDisplayName` functions by directly returning the result of the `set` method. [[1]](diffhunk://#diff-4d6799a33b2a8c7d1cd4da5b58db03a456ed0a3a2f5256135a651909255f7380L182-R182) [[2]](diffhunk://#diff-4d6799a33b2a8c7d1cd4da5b58db03a456ed0a3a2f5256135a651909255f7380L201-R199)
* [`internal/services/workspace/data_workspace.go`](diffhunk://#diff-56f9c23c9a9645da1fae3a5fb8a2019a63fe3ccc69d44b973c1cc4e733df273bL219-R219): Simplified the `getByID` function by directly returning the result of the `set` method.

### Import Additions:

* [`internal/services/warehouse/models.go`](diffhunk://#diff-0aacd0215ae3cf337fa3398273f0894beeb7477304eadaf56cbcc35f8eb3beb7R11): Added the `diag` package import to support diagnostic handling.
* [`internal/services/warehouse/resource_warehouse.go`](diffhunk://#diff-e1a79435c57368cf2714ed40440d33240de87b6bd2bfbb8e82b1a7501478d3a4R15): Added the `diag` package import to support diagnostic handling.