### PR TITLE
ci(dependabot): add labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+    labels:
+      - "deps/github-actions"
+      - dependencies
 
   - package-ecosystem: devcontainers
     directory: /
@@ -21,6 +24,9 @@ updates:
       prefix: build
       prefix-development: chore
       include: scope
+    labels:
+      - "deps/devcontainer"
+      - dependencies
 
   - package-ecosystem: gomod
     directory: /
@@ -30,3 +36,6 @@ updates:
       prefix: build
       prefix-development: chore
       include: scope
+    labels:
+      - "deps/go"
+      - dependencies


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the `.github/dependabot.yml` file to add labels for dependencies across different package ecosystems.

## ✨ Description of new changes

Label additions:

* Added labels `deps/github-actions` and `dependencies` for the GitHub Actions package ecosystem.
* Added labels `deps/devcontainer` and `dependencies` for the devcontainers package ecosystem.
* Added labels `deps/go` and `dependencies` for the Go modules package ecosystem.