### PR TITLE
feat: improve devenv setup and ci for test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,7 +61,8 @@
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": {
-    "git-safe-dir": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+    "git-safe-dir": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+    "pwsh-chown": "sudo chown -R vscode:vscode /home/vscode/.local/share/powershell"
   },
   // "privileged": true,
   "remoteUser": "vscode",
@@ -86,8 +87,9 @@
         "terminal.integrated.defaultProfile.linux": "zsh",
         "terminal.integrated.defaultProfile.osx": "zsh",
         "powershell.powerShellAdditionalExePaths": {
-          "pwsh": "/usr/local/bin/pwsh"
-        }
+          "pwsh": "/usr/bin/pwsh"
+        },
+        "powershell.powerShellDefaultVersion": "pwsh"
       },
       "extensions": [
         "golang.go",
@@ -109,6 +111,7 @@
         "darkriszty.markdown-table-prettify",
         "TakumiI.markdowntable",
         "hashicorp.terraform",
+        "ms-azuretools.vscode-azure-github-copilot",
         "ms-azuretools.vscode-azureterraform",
         "ms-azuretools.vscode-docker",
         "ms-vscode-remote.vscode-remote-extensionpack",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
     // "ghcr.io/guiyomh/features/gomarkdoc:0": {},
     // "ghcr.io/guiyomh/features/gotestsum:0": {},
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "installSentinel": true,
       "installTFsec": true,
       "installTerraformDocs": true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,14 @@ permissions:
 
 jobs:
   changes:
-    name: ✔️ Check for changes
+    name: 🔂 Check Changes
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: ✔️ Changes
+      - name: 🔂 Check for changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,29 @@ permissions:
   pull-requests: read
 
 jobs:
+  changes:
+    name: ✔️ Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - name: ⤵️ Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: ✔️ Changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            src:
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/test.yml'
+
   test-auth-spn:
     name: 🔐 Test Auth (SPN ${{ matrix.method }})
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     environment:
       name: development
     runs-on: ubuntu-latest
@@ -44,48 +65,32 @@ jobs:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: ✔️ Check for changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes_check
-        with:
-          filters: |
-            src:
-              - '**.go'
-              - 'go.mod'
-              - 'go.sum'
-              - '.github/workflows/test.yml'
-
       - name: 🚧 Setup Go
-        if: steps.changes_check.outputs.src == 'true'
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: 🚧 Setup Task
-        if: steps.changes_check.outputs.src == 'true'
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           repo-token: ${{ github.token }}
 
       - name: ⚙️ Configure TF dev overrides
-        if: steps.changes_check.outputs.src == 'true'
         run: .devcontainer/features/tfprovider-local-dev/install.sh
         env:
           PROVIDERNAME: microsoft/fabric
 
       - name: 🚧 Setup Terraform
-        if: steps.changes_check.outputs.src == 'true'
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 
       - name: 🔨 Setup Test tools
-        if: steps.changes_check.outputs.src == 'true'
         run: task test:tools
 
       - name: 🧪 Run acceptance tests (OIDC)
-        if: ${{ matrix.method == 'oidc' && steps.changes_check.outputs.src == 'true' }}
+        if: matrix.method == 'oidc'
         run: task testacc -- WorkspaceResource_CRUD ./internal/services/workspace
         env:
           FABRIC_USE_OIDC: true
@@ -93,7 +98,7 @@ jobs:
           FABRIC_CLIENT_ID: ${{ secrets.TESTACC_SPN_OIDC_CLIENT_ID }}
 
       - name: 🧪 Run acceptance tests (Certificate)
-        if: ${{ matrix.method == 'certificate' && steps.changes_check.outputs.src == 'true' }}
+        if: matrix.method == 'certificate'
         run: task testacc -- WorkspaceResource_CRUD ./internal/services/workspace
         env:
           FABRIC_TENANT_ID: ${{ secrets.TESTACC_TENANT_ID }}
@@ -102,7 +107,7 @@ jobs:
           FABRIC_CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.TESTACC_SPN_CERT_CLIENT_CERTIFICATE_PASSWORD }}
 
       - name: 🧪 Run acceptance tests (Secret)
-        if: ${{ matrix.method == 'secret' && steps.changes_check.outputs.src == 'true' }}
+        if: matrix.method == 'secret'
         run: task testacc -- WorkspaceResource_CRUD ./internal/services/workspace
         env:
           FABRIC_TENANT_ID: ${{ secrets.TESTACC_TENANT_ID }}
@@ -111,6 +116,8 @@ jobs:
 
   # test-auth-msi:
   #   name: 🔐 Test Auth (MSI ${{ matrix.method }})
+  #   needs: changes
+  #   if: needs.changes.outputs.src == 'true'
   #   environment:
   #     name: development
   #   runs-on: [self-hosted, containerjob]
@@ -133,36 +140,31 @@ jobs:
   #             - 'go.sum'
 
   #     - name: 🚧 Setup Go
-  #       if: steps.changes_check.outputs.src == 'true'
   #       uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
   #       with:
   #         go-version-file: go.mod
   #         cache: true
 
   #     - name: 🚧 Setup Task
-  #       if: steps.changes_check.outputs.src == 'true'
   #       uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
   #       with:
   #         repo-token: ${{ github.token }}
 
   #     - name: ⚙️ Configure TF dev overrides
-  #       if: steps.changes_check.outputs.src == 'true'
   #       run: .devcontainer/features/tfprovider-local-dev/install.sh
   #       env:
   #         PROVIDERNAME: microsoft/fabric
 
   #     - name: 🚧 Setup Terraform
-  #       if: steps.changes_check.outputs.src == 'true'
   #       uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
   #       with:
   #         terraform_wrapper: false
 
   #     - name: 🔨 Setup Test tools
-  #       if: steps.changes_check.outputs.src == 'true'
   #       run: task test:tools
 
   #     - name: 🧪 Run acceptance tests (User Assigned)
-  #       if: ${{ matrix.method == 'user' && steps.changes_check.outputs.src == 'true' }}
+  #       if: matrix.method == 'user'
   #       run: task testacc -- WorkspaceResource_CRUD
   #       env:
   #         FABRIC_USE_MSI: true
@@ -170,7 +172,7 @@ jobs:
   #         FABRIC_CLIENT_ID: ${{ secrets.TESTACC_MSI_CLIENT_ID }}
 
   #     - name: 🧪 Run acceptance tests (System Assigned)
-  #       if: ${{ matrix.method == 'system' && steps.changes_check.outputs.src == 'true' }}
+  #       if: matrix.method == 'system'
   #       run: task testacc -- WorkspaceResource_CRUD
   #       env:
   #         FABRIC_USE_MSI: true
@@ -178,6 +180,8 @@ jobs:
 
   checkbuild:
     name: 🏗️ Check Build
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -187,48 +191,31 @@ jobs:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: ✔️ Check for changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes_check
-        with:
-          filters: |
-            src:
-              - '**.go'
-              - 'go.mod'
-              - 'go.sum'
-              - '.github/workflows/test.yml'
-
       - name: 🚧 Setup Go
-        if: steps.changes_check.outputs.src == 'true'
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: 🚧 Setup Task
-        if: steps.changes_check.outputs.src == 'true'
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           repo-token: ${{ github.token }}
 
       - name: 🔀 Get dependencies
-        if: steps.changes_check.outputs.src == 'true'
         run: task deps
 
       - name: 🔀 Check for differences
-        if: steps.changes_check.outputs.src == 'true'
         run: |
           git diff --exit-code -- go.mod go.sum || \
             (echo; echo "Unexpected difference in go.mod/go.sum files. Run 'task deps' command or revert any go.mod/go.sum changes and commit."; git diff --exit-code)
 
       - name: ✔️ Run GoVulnCheck
-        if: steps.changes_check.outputs.src == 'true'
         run: |
           task install:govulncheck
           task govulncheck
 
       - name: ✔️ Run Go linters
-        if: steps.changes_check.outputs.src == 'true'
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           version: latest
@@ -238,19 +225,16 @@ jobs:
           args: --out-format=github-actions
 
       - name: 🚧 Setup Terraform
-        if: steps.changes_check.outputs.src == 'true'
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 
       - name: ✔️ Run tfproviderlintx
-        if: steps.changes_check.outputs.src == 'true'
         run: |
           task install:tfproviderlintx
           task tfproviderlintx
 
       - name: ✔️ Run Terraform linters
-        if: steps.changes_check.outputs.src == 'true'
         run: |
           task lint:tf-tools
           task lint:tf
@@ -267,7 +251,6 @@ jobs:
           args: check --verbose
 
       - name: 🏗️ Build snapshot binaries
-        if: steps.changes_check.outputs.src == 'true'
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           version: "~> v2"
@@ -318,7 +301,8 @@ jobs:
   # Run tests in a matrix with Terraform CLI versions
   test:
     name: 🧪 Run Tests (${{ matrix.cli }} ${{ matrix.version }})
-    # needs: checkbuild
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     environment:
       name: development
     runs-on: ubuntu-latest
@@ -329,8 +313,6 @@ jobs:
       checks: write
       pull-requests: write
       id-token: write
-    outputs:
-      changes: ${{ steps.changes_check.outputs.src }}
     strategy:
       fail-fast: false
       matrix:
@@ -349,45 +331,33 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ✔️ Check for changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes_check
-        with:
-          filters: |
-            src:
-              - '**.go'
-              - 'go.mod'
-              - 'go.sum'
-              - '.github/workflows/test.yml'
-
       - name: 🚧 Setup Go
-        if: steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target'
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: 🚧 Setup Terraform
-        if: matrix.cli == 'terraform' && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: matrix.cli == 'terraform'
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ matrix.version }}
           terraform_wrapper: false
 
       - name: ⚙️ Configure Terraform
-        if: matrix.cli == 'terraform' && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: matrix.cli == 'terraform'
         run: |
           terraform -version
 
       - name: 🚧 Setup OpenTofu
         uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
-        if: matrix.cli == 'tofu' && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: matrix.cli == 'tofu'
         with:
           tofu_version: ${{ matrix.version }}
           tofu_wrapper: false
 
       - name: ⚙️ Configure OpenTofu
-        if: matrix.cli == 'tofu' && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: matrix.cli == 'tofu'
         run: |
           echo "TERRAFORM_CLI=$(which tofu)" >> $GITHUB_ENV
           echo "REGISTRY_HOST=registry.opentofu.org" >> $GITHUB_ENV
@@ -397,27 +367,23 @@ jobs:
           tofu -version
 
       - name: ⚙️ Set CLI version
-        if: steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target'
         run: |
           version=$(echo "${{ matrix.version }}" | sed 's/\./_/g')
           echo "CLI_VERSION=$version" >> $GITHUB_ENV
 
       - name: 🚧 Setup Task
-        if: steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target'
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           repo-token: ${{ github.token }}
 
       - name: 🔀 Download Go dependencies
-        if: steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target'
         run: task deps:download
 
       - name: 🔨 Setup Test tools
-        if: steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target'
         run: task test:tools
 
       - name: 🧪 Run tests
-        if: matrix.cli == 'terraform' && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: matrix.cli == 'terraform'
         run: task test
         timeout-minutes: 30
         env:
@@ -427,7 +393,7 @@ jobs:
           FABRIC_CLIENT_ID: ${{ secrets.TESTACC_SPN_TF_CLIENT_ID }}
 
       - name: 🧪 Run tests
-        if: matrix.cli == 'tofu' && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: matrix.cli == 'tofu'
         run: task test
         timeout-minutes: 30
         env:
@@ -436,7 +402,7 @@ jobs:
           FABRIC_CLIENT_ID: ${{ secrets.TESTACC_SPN_OT_CLIENT_ID }}
 
       - name: 📤 Upload test results
-        if: always() && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: always()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: ${{ format('{0}-{1}-test-results', matrix.cli, env.CLI_VERSION) }}
@@ -445,7 +411,7 @@ jobs:
           overwrite: true
 
       - name: 📤 Upload coverage results
-        if: always() && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: always()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: ${{ format('{0}-{1}-test-coverage-results', matrix.cli, env.CLI_VERSION) }}
@@ -459,7 +425,7 @@ jobs:
           overwrite: true
 
       - name: 📢 Publish test results
-        if: always() && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: always()
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         with:
           name: 📜 Test results (${{ matrix.cli }} ${{ matrix.version }})
@@ -467,7 +433,7 @@ jobs:
           path: testresults.xml
 
       - name: ⚙️ Get Coverage summary
-        if: always() && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: always()
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: coverage.xml
@@ -481,7 +447,7 @@ jobs:
           thresholds: "40 60"
 
       - name: 📤 Upload Coverage summary
-        if: always() && (steps.changes_check.outputs.src == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
+        if: always()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: ${{ format('{0}-{1}-test-coverage-summary', matrix.cli, env.CLI_VERSION) }}
@@ -491,9 +457,11 @@ jobs:
           overwrite: true
 
   coverage-summary:
-    if: always() && (needs.test.outputs.changes == 'true' || github.event_name != 'pull_request' || github.event_name != 'pull_request_target')
     name: 📔 Coverage Summary
-    needs: test
+    needs:
+      - test
+      - changes
+    if: always() && needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -481,7 +481,6 @@ jobs:
       - name: 📤 Upload results to Codecov
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
         with:
-          # token: ${{ secrets.CODECOV_TOKEN }}
           use_oidc: true
           files: ./coverage.out
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -16,6 +16,7 @@
 - [Debugging](#debugging)
   - [Debugging with VS Code](#debugging-with-vs-code)
 - [Testing](#testing)
+  - [Well-Known resources](#well-known-resources)
   - [Unit Tests](#unit-tests)
   - [Acceptance Tests](#acceptance-tests)
 - [Dependencies](#dependencies)
@@ -107,9 +108,9 @@ Local development is still possible on Windows, Linux and macOS, but requires ad
 #### Requirements
 
 - [Git](https://git-scm.com/downloads) `>= 2.44.0`
-- [Go](https://go.dev/doc/install) `>= 1.22.5`
+- [Go](https://go.dev/doc/install) `>= 1.23.4`
   - We recommend you to use Go version manager [go-nv/goenv](https://github.com/go-nv/goenv/blob/master/INSTALL.md)
-    - `goenv install 1.22.5`
+    - `goenv install 1.23.4`
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) `>= 1.8.1`
   - We recommend you to use Terraform version manager [tfutils/tfenv](https://github.com/tfutils/tfenv/blob/master/README.md)
     - `tfenv install 1.8.1`, `tfenv use 1.8.1`
@@ -286,7 +287,35 @@ This provider support [terraform plugin debugging](https://developer.hashicorp.c
 
 ## Testing
 
+### Well-Known resources
+
+To run tests, especially "Acceptance Tests" some resources on the Fabric, Entra and Azure DevOps side have to be pre-created first. To setup them, set input environment variables:
+
+```text
+# Required
+FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID="<ENTRA TENANT ID>"
+FABRIC_TESTACC_WELLKNOWN_AZURE_SUBSCRIPTION_ID="<AZURE SUBSCRIPTION ID>"
+FABRIC_TESTACC_WELLKNOWN_FABRIC_CAPACITY_NAME="<FABRIC CAPACITY NAME>"
+FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME="<AZURE DEVOPS ORGANIZATION NAME>"
+FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX="<RESOURCES PREFIX>"
+
+# Optional
+FABRIC_TESTACC_WELLKNOWN_NAME_SUFFIX=""
+FABRIC_TESTACC_WELLKNOWN_NAME_BASE=""
+```
+
+You can set those variables into `./wellknown.env` files as well.
+
+Then run:
+
+```shell
+task testacc:setup
+```
+
 ### Unit Tests
+
+> [!NOTE]
+> Unit tests won't create the actual resources since they will be run against a fake server.
 
 To run all unit tests
 
@@ -311,7 +340,7 @@ sudo chown -R vscode /go/pkg
 ### Acceptance Tests
 
 > [!NOTE]
-> Acceptance tests won't create the actual resources since they will be run against a mock server.
+> Acceptance tests will create the actual resources since they will be run against real APIs.
 
 To run all acceptance tests
 

--- a/tools/scripts/Set-WellKnown.ps1
+++ b/tools/scripts/Set-WellKnown.ps1
@@ -492,6 +492,29 @@ $itemNaming = @{
 
 $baseName = Get-BaseName
 $Env:FABRIC_TESTACC_WELLKNOWN_NAME_BASE = $baseName
+
+# Save env vars wellknown.env file
+$envVarNames = @(
+  'FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID',
+  'FABRIC_TESTACC_WELLKNOWN_AZURE_SUBSCRIPTION_ID',
+  'FABRIC_TESTACC_WELLKNOWN_FABRIC_CAPACITY_NAME',
+  'FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME',
+  'FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX',
+  'FABRIC_TESTACC_WELLKNOWN_NAME_SUFFIX',
+  'FABRIC_TESTACC_WELLKNOWN_NAME_BASE',
+  'FABRIC_TESTACC_WELLKNOWN_SPN_NAME'
+)
+
+$envVars = $envVarNames | ForEach-Object {
+  $envVarName = $_
+  if (Test-Path "Env:${envVarName}") {
+    $value = (Get-ChildItem "Env:${envVarName}").Value
+    "$envVarName=`"$value`""
+  }
+}
+
+$envVars -join "`n" | Set-Content -Path './wellknown.env' -Force -NoNewline -Encoding utf8
+
 $displayName = Get-DisplayName -Base $baseName
 
 # Create Workspace if not exists
@@ -761,24 +784,4 @@ $wellKnownJson = $wellKnown | ConvertTo-Json
 $wellKnownJson
 $wellKnownJson | Set-Content -Path './internal/testhelp/fixtures/.wellknown.json' -Force -NoNewline -Encoding utf8
 
-# Save env vars wellknown.env file
-$envVarNames = @(
-  'FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID',
-  'FABRIC_TESTACC_WELLKNOWN_AZURE_SUBSCRIPTION_ID',
-  'FABRIC_TESTACC_WELLKNOWN_FABRIC_CAPACITY_NAME',
-  'FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME',
-  'FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX',
-  'FABRIC_TESTACC_WELLKNOWN_NAME_SUFFIX',
-  'FABRIC_TESTACC_WELLKNOWN_NAME_BASE',
-  'FABRIC_TESTACC_WELLKNOWN_SPN_NAME'
-)
 
-$envVars = $envVarNames | ForEach-Object {
-  $envVarName = $_
-  if (Test-Path "Env:${envVarName}") {
-    $value = (Get-ChildItem "Env:${envVarName}").Value
-    "$envVarName=`"$value`""
-  }
-}
-
-$envVars -join "`n" | Set-Content -Path './wellknown.env' -Force -NoNewline -Encoding utf8

--- a/tools/scripts/Set-WellKnown.ps1
+++ b/tools/scripts/Set-WellKnown.ps1
@@ -403,7 +403,9 @@ foreach ($module in $modules) {
 }
 
 # Import the .env file into the environment variables
-Import-Dotenv -Path wellknown.env -SkipReadErrorCheck -AllowClobber
+if (Test-Path -Path './wellknown.env') {
+  Import-Dotenv -Path ./wellknown.env -AllowClobber
+}
 
 if (!$Env:FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID -or !$Env:FABRIC_TESTACC_WELLKNOWN_AZURE_SUBSCRIPTION_ID -or !$Env:FABRIC_TESTACC_WELLKNOWN_FABRIC_CAPACITY_NAME -or !$Env:FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME -or !$Env:FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX) {
   Write-Log -Message 'FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID, FABRIC_TESTACC_WELLKNOWN_AZURE_SUBSCRIPTION_ID, FABRIC_TESTACC_WELLKNOWN_FABRIC_CAPACITY_NAME, FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME and FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX are required environment variables.' -Level 'ERROR'
@@ -741,6 +743,29 @@ if ($SPN) {
   $result = Set-ADOPSGitPermission -ProjectId $azdoProject.id -RepositoryId $azdoRepo.id -Descriptor $azdoSPN.descriptor -Allow 'GenericContribute', 'PullRequestContribute', 'CreateBranch', 'CreateTag', 'GenericRead'
 }
 
+# Save wellknown.json file
 $wellKnownJson = $wellKnown | ConvertTo-Json
 $wellKnownJson
-$wellKnownJson | Set-Content -Path 'internal/testhelp/fixtures/.wellknown.json' -Force -NoNewline -Encoding utf8
+$wellKnownJson | Set-Content -Path './internal/testhelp/fixtures/.wellknown.json' -Force -NoNewline -Encoding utf8
+
+# Save env vars wellknown.env file
+$envVarNames = @(
+  'FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID',
+  'FABRIC_TESTACC_WELLKNOWN_AZURE_SUBSCRIPTION_ID',
+  'FABRIC_TESTACC_WELLKNOWN_FABRIC_CAPACITY_NAME',
+  'FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME',
+  'FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX',
+  'FABRIC_TESTACC_WELLKNOWN_NAME_SUFFIX',
+  'FABRIC_TESTACC_WELLKNOWN_NAME_BASE',
+  'FABRIC_TESTACC_WELLKNOWN_SPN_NAME'
+)
+
+$envVars = $envVarNames | ForEach-Object {
+  $envVarName = $_
+  if (Test-Path "Env:${envVarName}") {
+    $value = (Get-ChildItem "Env:${envVarName}").Value
+    "$envVarName=`"$value`""
+  }
+}
+
+$envVars -join "`n" | Set-Content -Path './wellknown.env' -Force -NoNewline -Encoding utf8

--- a/tools/scripts/Set-WellKnown.ps1
+++ b/tools/scripts/Set-WellKnown.ps1
@@ -401,7 +401,7 @@ function Get-DisplayName {
     $result = "${result}${Separator}${Suffix}"
   }
 
-  return $base
+  return $result
 }
 
 # Define an array of modules to install
@@ -436,7 +436,7 @@ if (!$azContext -or $azContext.Tenant.Id -ne $Env:FABRIC_TESTACC_WELLKNOWN_ENTRA
 Write-Log -Message 'Logging in to Azure DevOps.' -Level 'DEBUG'
 $secureAccessToken = (Get-AzAccessToken -WarningAction SilentlyContinue -AsSecureString -ResourceUrl '499b84ac-1321-427f-aa17-267ca6975798').Token
 $unsecureAccessToken = $secureAccessToken | ConvertFrom-SecureString -AsPlainText
-$azdoContext = Connect-ADOPS -TenantId $Env:FABRIC_TESTACC_WELLKNOWN_ENTRA_TENANT_ID -Organization $Env:FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME -OAuthToken $unsecureAccessToken
+$azdoContext = Connect-ADOPS -TenantId $azContext.Tenant.Id -Organization $Env:FABRIC_TESTACC_WELLKNOWN_AZDO_ORGANIZATION_NAME -OAuthToken $unsecureAccessToken
 
 $SPN = $null
 if ($Env:FABRIC_TESTACC_WELLKNOWN_SPN_NAME) {
@@ -710,7 +710,7 @@ if (!$result) {
 }
 $wellKnown['Datamart'] = @{
   id          = if ($result) { $result.id } else { '00000000-0000-0000-0000-000000000000' }
-  displayName = if ($result) { $result.displayName } else { $displayNameDatamart }
+  displayName = if ($result) { $result.displayName } else { $displayNameTemp }
   description = if ($result) { $result.description } else { '' }
 }
 

--- a/tools/scripts/Set-WellKnown.ps1
+++ b/tools/scripts/Set-WellKnown.ps1
@@ -360,17 +360,8 @@ function Set-FabricDomain {
   return $result
 }
 
-function Get-DisplayName {
+function Get-BaseName {
   param (
-    [Parameter(Mandatory = $false)]
-    [string]$Prefix = $Env:FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX,
-
-    [Parameter(Mandatory = $false)]
-    [string]$Suffix = $Env:FABRIC_TESTACC_WELLKNOWN_NAME_SUFFIX,
-
-    [Parameter(Mandatory = $false)]
-    [string]$Separator = '_',
-
     [Parameter(Mandatory = $false)]
     [int]$Length = 10
   )
@@ -381,13 +372,33 @@ function Get-DisplayName {
     $base = -join ((65..90) + (97..122) | Get-Random -Count $Length | ForEach-Object { [char]$_ })
   }
 
+  return $base
+}
+
+function Get-DisplayName {
+  param (
+    [Parameter(Mandatory = $true)]
+    [string]$Base,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Prefix = $Env:FABRIC_TESTACC_WELLKNOWN_NAME_PREFIX,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Suffix = $Env:FABRIC_TESTACC_WELLKNOWN_NAME_SUFFIX,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Separator = '_'
+  )
+
+  $result = $Base
+
   # add prefix and suffix
   if ($Prefix) {
-    $base = "$Prefix$Separator$base"
+    $result = "${Prefix}${Separator}${result}"
   }
 
   if ($Suffix) {
-    $base = "$base$Separator$Suffix"
+    $result = "${result}${Separator}${Suffix}"
   }
 
   return $base
@@ -479,7 +490,9 @@ $itemNaming = @{
   'AzDOProject'           = 'proj'
 }
 
-$displayName = Get-DisplayName
+$baseName = Get-BaseName
+$Env:FABRIC_TESTACC_WELLKNOWN_NAME_BASE = $baseName
+$displayName = Get-DisplayName -Base $baseName
 
 # Create Workspace if not exists
 $displayNameTemp = "${displayName}_$($itemNaming['Workspace'])"


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the `.devcontainer/devcontainer.json` and significant modifications to the `.github/workflows/test.yml` file to streamline the CI/CD process and ensure proper environment setup.

## ✨ Description of new changes


### Updates to `.devcontainer/devcontainer.json`:
* Updated the Terraform version from `1.10.2` to `1.10.3` to ensure the latest features and fixes are included.
* Added a command to change ownership of the PowerShell directory to the `vscode` user after the container is created.
* Changed the path for `pwsh` and set `powershell.powerShellDefaultVersion` to `pwsh`.
* Added the `ms-azuretools.vscode-azure-github-copilot` extension to the list of recommended extensions.

### Modifications to `.github/workflows/test.yml`:
* Reorganized jobs to ensure that the `changes` job runs first and subsequent jobs depend on its output, improving efficiency by only running tests if there are relevant changes. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L34-R44) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R53-R101)
* Removed redundant `if` conditions that checked for changes, simplifying the workflow and reducing unnecessary checks. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L105-R110) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L136-R184) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L190-L231) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L241-L253) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L270) [[6]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L321-R305) [[7]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L332-L333) [[8]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L352-R360) [[9]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L400-R386) [[10]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L430-R396) [[11]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L439-R405) [[12]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L448-R414) [[13]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L462-R436) [[14]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L484-R450) [[15]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L494-R464)
* Ensured that the `coverage-summary` job runs only if there are relevant changes, improving the efficiency of the CI/CD pipeline.
* Updated the `checkout` and `setup-go` actions to use specific commit hashes for better reliability and reproducibility. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L190-L231) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L270)