### PR TITLE
fix(domain): workspace assignments should only care about managed resources

### DIFF
--- a/.changes/unreleased/fixed-20250108-115142.yaml
+++ b/.changes/unreleased/fixed-20250108-115142.yaml
@@ -1,6 +1,6 @@
 kind: fixed
 body: |
-  `Provider produced inconsistent result after apply` error appears when using `fabric_domain_workspace_assignments` multiple times due to enforce assignments based only on TF configuration and ignoring the real state on teh Fabric side.
+  `Provider produced inconsistent result after apply` error appears when using `fabric_domain_workspace_assignments` multiple times due to enforce assignments based only on TF configuration and ignoring the real state on the Fabric side.
   Resource must only manage TF provided configuration and ignore any configuration provided outside TF.
 time: 2025-01-08T11:51:42.1488752-08:00
 custom:

--- a/.changes/unreleased/fixed-20250108-115142.yaml
+++ b/.changes/unreleased/fixed-20250108-115142.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: |
+  `Provider produced inconsistent result after apply` error appears when using `fabric_domain_workspace_assignments` multiple times due to enforce assignments based only on TF configuration and ignoring the real state on teh Fabric side.
+  Resource must only manage TF provided configuration and ignore any configuration provided outside TF.
+time: 2025-01-08T11:51:42.1488752-08:00
+custom:
+  Issue: "174"

--- a/docs/resources/domain_workspace_assignments.md
+++ b/docs/resources/domain_workspace_assignments.md
@@ -43,7 +43,7 @@ resource "fabric_domain_workspace_assignments" "example" {
 ### Required
 
 - `domain_id` (String) The Domain ID. Changing this forces a new resource to be created.
-- `workspace_ids` (Set of String) The list of Workspaces.
+- `workspace_ids` (Set of String) The set of Workspace IDs.
 
 ### Optional
 

--- a/internal/services/domain/models_resource_domain_workspace_assignments.go
+++ b/internal/services/domain/models_resource_domain_workspace_assignments.go
@@ -21,11 +21,11 @@ type resourceDomainWorkspaceAssignmentsModel struct {
 	Timeouts     timeouts.Value   `tfsdk:"timeouts"`
 }
 
-func (to *resourceDomainWorkspaceAssignmentsModel) setWorkspaces(ctx context.Context, from []fabadmin.DomainWorkspace) diag.Diagnostics {
-	elements := []customtypes.UUID{}
+func (to *resourceDomainWorkspaceAssignmentsModel) setWorkspaces(ctx context.Context, from []string) diag.Diagnostics {
+	elements := make([]customtypes.UUID, 0, len(from))
 
-	for _, entity := range from {
-		elements = append(elements, customtypes.NewUUIDPointerValue(entity.ID))
+	for _, element := range from {
+		elements = append(elements, customtypes.NewUUIDValue(element))
 	}
 
 	values, diags := types.SetValueFrom(ctx, customtypes.UUIDType{}, elements)
@@ -69,14 +69,13 @@ func (to *requestDeleteDomainWorkspaceAssignments) set(ctx context.Context, from
 }
 
 func getWorkspaceIDs(ctx context.Context, from resourceDomainWorkspaceAssignmentsModel) ([]string, diag.Diagnostics) {
-	values := []string{}
-
 	elements := make([]customtypes.UUID, 0, len(from.WorkspaceIDs.Elements()))
 
-	diags := from.WorkspaceIDs.ElementsAs(ctx, &elements, false)
-	if diags.HasError() {
+	if diags := from.WorkspaceIDs.ElementsAs(ctx, &elements, false); diags.HasError() {
 		return nil, diags
 	}
+
+	values := make([]string, 0, len(elements))
 
 	for _, element := range elements {
 		values = append(values, element.ValueString())


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

- Currently `domain_workspace_assignments` resource enforce assignments based only on TF configuration. It means if someone adds more resources manually on the Fabric side, the next run of TF will remove it. Expected behavior: Resource must only manage TF provided configuration.

This fix is related (not directly) to #174 and potentially to #183
