### PR TITLE
build(deps): update go to 1.23.6 and terraform to 1.10.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     },
     // "ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.23.5"
+      "version": "1.23.6"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
@@ -36,7 +36,7 @@
     // "ghcr.io/guiyomh/features/gomarkdoc:0": {},
     // "ghcr.io/guiyomh/features/gotestsum:0": {},
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.10.4",
+      "version": "1.10.5",
       "installSentinel": true,
       "installTFsec": true,
       "installTerraformDocs": true

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -108,12 +108,12 @@ Local development is still possible on Windows, Linux and macOS, but requires ad
 #### Requirements
 
 - [Git](https://git-scm.com/downloads) `>= 2.47.1`
-- [Go](https://go.dev/doc/install) `>= 1.23.5`
+- [Go](https://go.dev/doc/install) `>= 1.23.6`
   - We recommend you to use Go version manager [go-nv/goenv](https://github.com/go-nv/goenv/blob/master/INSTALL.md)
-    - `goenv install 1.23.5`
-- [Terraform](https://developer.hashicorp.com/terraform/downloads) `>= 1.10.4`
+    - `goenv install 1.23.6`
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) `>= 1.10.5`
   - We recommend you to use Terraform version manager [tfutils/tfenv](https://github.com/tfutils/tfenv/blob/master/README.md)
-    - `tfenv install 1.10.4`, `tfenv use 1.10.4`
+    - `tfenv install 1.10.5`, `tfenv use 1.10.5`
 - [Task](https://taskfile.dev/installation) `>= 3.40.1`
 
 #### Linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/terraform-provider-fabric
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the versions of Go and Terraform across various configuration and documentation files to ensure consistency and compatibility.

Version updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L18-R18): Updated the Go feature version from `1.23.5` to `1.23.6`.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L39-R39): Updated the Terraform feature version from `1.10.4` to `1.10.5`.
* [`DEVELOPER.md`](diffhunk://#diff-35ea617bfbf0780bfbc554348314c5b11ba478a4d98fd92d33d45cdd54bf326aL111-R116): Updated the required versions of Go and Terraform to `1.23.6` and `1.10.5` respectively, and adjusted the version manager instructions accordingly.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.5` to `1.23.6`.