### PR TITLE
fix(semantic-model-tmdl): add missing paths

### DIFF
--- a/.changes/unreleased/fixed-20250212-122940.yaml
+++ b/.changes/unreleased/fixed-20250212-122940.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Add support for missing `definition/expressions.tmdl` and `definition/relationships.tmdl` paths in the Semantic Model TMDL format.
+time: 2025-02-12T12:29:40.6415539+01:00
+custom:
+  Issue: "247"

--- a/docs/data-sources/semantic_model.md
+++ b/docs/data-sources/semantic_model.md
@@ -63,7 +63,7 @@ output "example_definition_bim_object" {
 
 ### Read-Only
 
-- `definition` (Attributes Map) Definition parts. Possible path keys: **TMDL** format: `definition.pbism`, `definition/database.tmdl`, `definition/model.tmdl`, `definition/tables/*.tmdl`, `diagramLayp.json` **TMSL** format: `definition.pbism`, `diagramLayp.json`, `model.bim` (see [below for nested schema](#nestedatt--definition))
+- `definition` (Attributes Map) Definition parts. Possible path keys: **TMDL** format: `definition.pbism`, `definition/database.tmdl`, `definition/expressions.tmdl`, `definition/model.tmdl`, `definition/relationships.tmdl`, `definition/tables/*.tmdl`, `diagramLayp.json` **TMSL** format: `definition.pbism`, `diagramLayp.json`, `model.bim` (see [below for nested schema](#nestedatt--definition))
 - `description` (String) The Semantic Model description.
 - `display_name` (String) The Semantic Model display name.
 

--- a/docs/resources/semantic_model.md
+++ b/docs/resources/semantic_model.md
@@ -59,7 +59,7 @@ resource "fabric_semantic_model" "example_update" {
 
 ### Required
 
-- `definition` (Attributes Map) Definition parts. Read more about [Semantic Model definition part paths](https://learn.microsoft.com/rest/api/fabric/articles/item-management/definitions/semantic-model-definition). Accepted path keys: **TMDL** format: `definition.pbism`, `definition/database.tmdl`, `definition/model.tmdl`, `definition/tables/*.tmdl`, `diagramLayp.json` **TMSL** format: `definition.pbism`, `diagramLayp.json`, `model.bim` (see [below for nested schema](#nestedatt--definition))
+- `definition` (Attributes Map) Definition parts. Read more about [Semantic Model definition part paths](https://learn.microsoft.com/rest/api/fabric/articles/item-management/definitions/semantic-model-definition). Accepted path keys: **TMDL** format: `definition.pbism`, `definition/database.tmdl`, `definition/expressions.tmdl`, `definition/model.tmdl`, `definition/relationships.tmdl`, `definition/tables/*.tmdl`, `diagramLayp.json` **TMSL** format: `definition.pbism`, `diagramLayp.json`, `model.bim` (see [below for nested schema](#nestedatt--definition))
 - `display_name` (String) The Semantic Model display name.
 - `format` (String) The Semantic Model format. Possible values: `TMDL`, `TMSL`
 - `workspace_id` (String) The Workspace ID.

--- a/internal/services/semanticmodel/base.go
+++ b/internal/services/semanticmodel/base.go
@@ -30,6 +30,6 @@ var itemDefinitionFormats = []fabricitem.DefinitionFormat{ //nolint:gochecknoglo
 	{
 		Type:  "TMDL",
 		API:   "TMDL",
-		Paths: []string{"definition/database.tmdl", "definition/model.tmdl", "definition.pbism", "diagramLayp.json", "definition/tables/*.tmdl"},
+		Paths: []string{"definition/database.tmdl", "definition/model.tmdl", "definition/expressions.tmdl", "definition/relationships.tmdl", "definition.pbism", "diagramLayp.json", "definition/tables/*.tmdl"},
 	},
 }


### PR DESCRIPTION
# 📥 Pull Request

fix #247

## ❓ What are you trying to address

Add support for missing `definition/expressions.tmdl` and `definition/relationships.tmdl` paths in the Semantic Model TMDL format.