### PR TITLE
fix(logging): enable sdk logging only when target level is not set to off

### DIFF
--- a/internal/provider/client/logging.go
+++ b/internal/provider/client/logging.go
@@ -23,8 +23,10 @@ func NewFabricSDKLoggerSubsystem(ctx context.Context) (context.Context, hclog.Le
 	// If the level is not set, or is set to "off", disable logging
 	if targetLevel == hclog.NoLevel {
 		targetLevel = hclog.Off
-	} else {
-		// Enable azcore logging
+	}
+
+	// Enable azcore logging if the target level is not "off"
+	if targetLevel != hclog.Off {
 		err := os.Setenv(AzureSDKLoggingEnvVar, AzureSDKLoggingAll)
 		if err != nil {
 			return ctx, targetLevel, err


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes a change to the `internal/provider/client/logging.go` file to improve the logging configuration for the Fabric SDK. The most important change is the modification of the logic that enables Azure SDK logging based on the target logging level.

Logging configuration improvement:

* [`internal/provider/client/logging.go`](diffhunk://#diff-b0adf1bef9698ebb0eabbadf00f5b31f6b21717837649818498f1c23a1968f8aL26-R29): Adjusted the logic to enable Azure SDK logging only if the target logging level is not set to "off". This ensures that logging is properly configured based on the specified level.
