### PR TITLE
ci(deps): update terraform to 1.11.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
     // "ghcr.io/guiyomh/features/gomarkdoc:0": {},
     // "ghcr.io/guiyomh/features/gotestsum:0": {},
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.10.5",
+      "version": "1.11.0",
       "installSentinel": true,
       "installTFsec": true,
       "installTerraformDocs": true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -479,7 +479,7 @@ jobs:
       - name: 📥 Download
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          pattern: terraform-1_10-test-coverage*
+          pattern: terraform-1_11-test-coverage*
           merge-multiple: true
 
       - name: 📝 Publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -318,16 +318,20 @@ jobs:
       fail-fast: false
       matrix:
         cli: [terraform, tofu]
-        version: ["1.7", "1.8", "1.9", "1.10"]
+        version: ["1.7", "1.8", "1.9", "1.10", "1.11"]
         exclude:
           - cli: terraform
             version: "1.7"
           - cli: terraform
             version: "1.9"
+          - cli: terraform
+            version: "1.10"
           - cli: tofu
             version: "1.8"
           - cli: tofu
             version: "1.10"
+          - cli: tofu
+            version: "1.11"
     steps:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -111,9 +111,9 @@ Local development is still possible on Windows, Linux and macOS, but requires ad
 - [Go](https://go.dev/doc/install) `>= 1.24.0`
   - We recommend you to use Go version manager [go-nv/goenv](https://github.com/go-nv/goenv/blob/master/INSTALL.md)
     - `goenv install 1.24.0`
-- [Terraform](https://developer.hashicorp.com/terraform/downloads) `>= 1.10.5`
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) `>= 1.11.0`
   - We recommend you to use Terraform version manager [tfutils/tfenv](https://github.com/tfutils/tfenv/blob/master/README.md)
-    - `tfenv install 1.10.5`, `tfenv use 1.10.5`
+    - `tfenv install 1.11.0`, `tfenv use 1.11.0`
 - [Task](https://taskfile.dev/installation) `>= 3.40.1`
 
 #### Linux


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to the Terraform version used in various configuration files and documentation. 

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L39-R39): Updated the Terraform version from `1.10.5` to `1.11.0`.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L321-R334): Added Terraform version `1.11` to the matrix and excluded it from specific tests.
* [`DEVELOPER.md`](diffhunk://#diff-35ea617bfbf0780bfbc554348314c5b11ba478a4d98fd92d33d45cdd54bf326aL114-R116): Updated the recommended Terraform version from `1.10.5` to `1.11.0` in the development setup instructions.