### PR TITLE
fix(wellknown): enhance Install-Module command with additional params

### DIFF
--- a/tools/scripts/Set-WellKnown.ps1
+++ b/tools/scripts/Set-WellKnown.ps1
@@ -42,7 +42,7 @@ function Install-ModuleIfNotInstalled {
   if (-not (Get-Module -Name $ModuleName -ListAvailable)) {
     try {
       Write-Log -Message "Installing module: $ModuleName" -Level 'DEBUG'
-      Install-Module -Name $ModuleName -AllowClobber -Force -Scope CurrentUser -Repository PSGallery
+      Install-Module -Name $ModuleName -AllowClobber -Force -Scope CurrentUser -Repository PSGallery -Confirm:$false -SkipPublisherCheck -AcceptLicense
     }
     catch {
       Write-Error $_.Exception.Message


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes a small change to the `tools/scripts/Set-WellKnown.ps1` file. The change modifies the `Install-Module` command within the `Install-ModuleIfNotInstalled` function to include additional parameters for skipping publisher checks, accepting licenses, and disabling confirmation prompts.

* [`tools/scripts/Set-WellKnown.ps1`](diffhunk://#diff-cd040f9d9e24e510ff0d29df8f78489fbd234634352aa2fbbf2b99a9a52fcc4cL45-R45): Modified the `Install-Module` command to include `-Confirm:$false`, `-SkipPublisherCheck`, and `-AcceptLicense` parameters.
