### PR TITLE
fix(docs): add default format to data pipeline resources examples

### DIFF
--- a/.changes/unreleased/fixed-20250313-090918.yaml
+++ b/.changes/unreleased/fixed-20250313-090918.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Add missing required `format` attribute to the `fabric_data_pipeline` Resource example.
+time: 2025-03-13T09:09:18.9310599-07:00
+custom:
+    Issue: "303"

--- a/docs/resources/data_pipeline.md
+++ b/docs/resources/data_pipeline.md
@@ -33,6 +33,7 @@ resource "fabric_data_pipeline" "example_definition_bootstrap" {
   display_name              = "example"
   description               = "example with definition bootstrapping"
   workspace_id              = "00000000-0000-0000-0000-000000000000"
+  format                    = "Default"
   definition_update_enabled = false
   definition = {
     "pipeline-content.json" = {
@@ -49,6 +50,7 @@ resource "fabric_data_pipeline" "example_definition_update" {
   display_name = "example"
   description  = "example with definition update when source or tokens changed"
   workspace_id = "00000000-0000-0000-0000-000000000000"
+  format       = "Default"
   definition = {
     "pipeline-content.json" = {
       source = "${local.path}/pipeline-content.json"

--- a/examples/resources/fabric_data_pipeline/resource.tf
+++ b/examples/resources/fabric_data_pipeline/resource.tf
@@ -9,6 +9,7 @@ resource "fabric_data_pipeline" "example_definition_bootstrap" {
   display_name              = "example"
   description               = "example with definition bootstrapping"
   workspace_id              = "00000000-0000-0000-0000-000000000000"
+  format                    = "Default"
   definition_update_enabled = false
   definition = {
     "pipeline-content.json" = {
@@ -25,6 +26,7 @@ resource "fabric_data_pipeline" "example_definition_update" {
   display_name = "example"
   description  = "example with definition update when source or tokens changed"
   workspace_id = "00000000-0000-0000-0000-000000000000"
+  format       = "Default"
   definition = {
     "pipeline-content.json" = {
       source = "${local.path}/pipeline-content.json"


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes changes to add a new `format` attribute to various `fabric_data_pipeline` resources in both documentation and example files. The most important changes are as follows:

Documentation updates:
* [`docs/resources/data_pipeline.md`](diffhunk://#diff-5c0014d01c92e5f78fb4d1486a8d97af0281e84589e065fd9d3b8bd56bda02a4R36): Added the `format` attribute with the value "Default" to the `fabric_data_pipeline` resource examples. [[1]](diffhunk://#diff-5c0014d01c92e5f78fb4d1486a8d97af0281e84589e065fd9d3b8bd56bda02a4R36) [[2]](diffhunk://#diff-5c0014d01c92e5f78fb4d1486a8d97af0281e84589e065fd9d3b8bd56bda02a4R53)

Example updates:
* [`examples/resources/fabric_data_pipeline/resource.tf`](diffhunk://#diff-65be83977c8ef370144f56df858fd47cf90090c74ba7c1feab0aadfd7743e41cR12): Added the `format` attribute with the value "Default" to the `fabric_data_pipeline` resource examples. [[1]](diffhunk://#diff-65be83977c8ef370144f56df858fd47cf90090c74ba7c1feab0aadfd7743e41cR12) [[2]](diffhunk://#diff-65be83977c8ef370144f56df858fd47cf90090c74ba7c1feab0aadfd7743e41cR29)
