### PR TITLE
feat(logging): add sdk log options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "program": "${workspaceFolder}",
       "env": {
         "FABRIC_PREVIEW": "true",
-        "FABRIC_SDK_GO_LOGGING": "trace"
+        "FABRIC_SDK_GO_LOGGING": "trace",
+        "FABRIC_SDK_GO_LOGGING_INCLUDE_BODY": "true"
       },
       "args": [
         "-debug"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,7 +63,8 @@
     "TF_LOG": "ERROR",
     "TF_ACC": "1",
     "FABRIC_PREVIEW": "true",
-    "FABRIC_SDK_GO_LOGGING": "trace"
+    "FABRIC_SDK_GO_LOGGING": "trace",
+    "FABRIC_SDK_GO_LOGGING_INCLUDE_BODY": "true"
   },
   "go.formatTool": "goimports",
   "go.formatFlags": [

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -142,6 +142,21 @@ func createDefaultClient(ctx context.Context, cfg *pconfig.ProviderConfig) (*fab
 	}
 
 	if cls := os.Getenv(pclient.AzureSDKLoggingEnvVar); cls == pclient.AzureSDKLoggingAll && lvl != hclog.Off {
+		var logOptions policy.LogOptions
+
+		if includeBody, ok := os.LookupEnv("FABRIC_SDK_GO_LOGGING_INCLUDE_BODY"); ok {
+			includeBodyBool, err := strconv.ParseBool(includeBody)
+			if err != nil {
+				return nil, err
+			}
+
+			logOptions.IncludeBody = includeBodyBool
+		}
+
+		logOptions.AllowedHeaders = []string{"requestid", "x-ms-operation-id", "x-ms-public-api-error-code", "home-cluster-uri", "location", "date", "retry-after"}
+
+		fabricClientOpt.Logging = logOptions
+
 		azlog.SetListener(func(ev azlog.Event, msg string) {
 			tflog.SubsystemTrace(ctx, pclient.FabricSDKLoggerName, "SDK", map[string]any{
 				"event":   ev,

--- a/internal/services/spark/resource_spark_environment_settings.go
+++ b/internal/services/spark/resource_spark_environment_settings.go
@@ -436,7 +436,7 @@ func (r *resourceSparkEnvironmentSettings) Update(ctx context.Context, req resou
 	}
 }
 
-func (r *resourceSparkEnvironmentSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *resourceSparkEnvironmentSettings) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "DELETE", map[string]any{
 		"action": "start",
 	})

--- a/internal/services/spark/resource_spark_workspace_settings.go
+++ b/internal/services/spark/resource_spark_workspace_settings.go
@@ -443,7 +443,7 @@ func (r *resourceSparkWorkspaceSettings) Update(ctx context.Context, req resourc
 	}
 }
 
-func (r *resourceSparkWorkspaceSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *resourceSparkWorkspaceSettings) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "DELETE", map[string]any{
 		"action": "start",
 	})


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes changes to enhance logging capabilities for the Fabric SDK Go. The most important changes include updating environment configurations and modifying the client creation function to include logging options.

Enhancements to logging capabilities:

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L12-R13): Added `FABRIC_SDK_GO_LOGGING_INCLUDE_BODY` environment variable to include request/response bodies in logs.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L66-R67): Added `FABRIC_SDK_GO_LOGGING_INCLUDE_BODY` environment variable to include request/response bodies in logs.
* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R145-R159): Modified `createDefaultClient` function to parse and set the `FABRIC_SDK_GO_LOGGING_INCLUDE_BODY` environment variable, and to configure allowed headers for logging.
