### PR TITLE
chore(examples): remove resource prefix

### DIFF
--- a/examples/resources/fabric_activator/outputs.tf
+++ b/examples/resources/fabric_activator/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_activator.example
+  value = fabric_activator.example
 }

--- a/examples/resources/fabric_data_pipeline/outputs.tf
+++ b/examples/resources/fabric_data_pipeline/outputs.tf
@@ -1,11 +1,11 @@
 output "example" {
-  value = resource.fabric_data_pipeline.example
+  value = fabric_data_pipeline.example
 }
 
 output "example_definition_bootstrap" {
-  value = resource.fabric_data_pipeline.example_definition_bootstrap
+  value = fabric_data_pipeline.example_definition_bootstrap
 }
 
 output "example_definition_update" {
-  value = resource.fabric_data_pipeline.example_definition_update
+  value = fabric_data_pipeline.example_definition_update
 }

--- a/examples/resources/fabric_domain/outputs.tf
+++ b/examples/resources/fabric_domain/outputs.tf
@@ -1,7 +1,7 @@
 output "parent" {
-  value = resource.fabric_domain.parent
+  value = fabric_domain.parent
 }
 
 output "parent" {
-  value = resource.fabric_domain.child
+  value = fabric_domain.child
 }

--- a/examples/resources/fabric_domain_role_assignments/outputs.tf
+++ b/examples/resources/fabric_domain_role_assignments/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_domain_role_assignments.example
+  value = fabric_domain_role_assignments.example
 }

--- a/examples/resources/fabric_domain_workspace_assignments/outputs.tf
+++ b/examples/resources/fabric_domain_workspace_assignments/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_domain_workspace_assignments.example
+  value = fabric_domain_workspace_assignments.example
 }

--- a/examples/resources/fabric_environment/outputs.tf
+++ b/examples/resources/fabric_environment/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_environment.example
+  value = fabric_environment.example
 }

--- a/examples/resources/fabric_eventhouse/outputs.tf
+++ b/examples/resources/fabric_eventhouse/outputs.tf
@@ -1,11 +1,11 @@
 output "example" {
-  value = resource.fabric_eventhouse.example
+  value = fabric_eventhouse.example
 }
 
 output "example_definition_bootstrap" {
-  value = resource.fabric_spark_job_definition.example_definition_bootstrap
+  value = fabric_spark_job_definition.example_definition_bootstrap
 }
 
 output "example_definition_update" {
-  value = resource.fabric_spark_job_definition.example_definition_update
+  value = fabric_spark_job_definition.example_definition_update
 }

--- a/examples/resources/fabric_eventstream/outputs.tf
+++ b/examples/resources/fabric_eventstream/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_eventstream.example
+  value = fabric_eventstream.example
 }

--- a/examples/resources/fabric_gateway/outputs.tf
+++ b/examples/resources/fabric_gateway/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_gateway.example
+  value = fabric_gateway.example
 }

--- a/examples/resources/fabric_gateway_role_assignment/outputs.tf
+++ b/examples/resources/fabric_gateway_role_assignment/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_gateway_role_assignment.example
+  value = fabric_gateway_role_assignment.example
 }

--- a/examples/resources/fabric_graphql_api/outputs.tf
+++ b/examples/resources/fabric_graphql_api/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_graphql_api.example
+  value = fabric_graphql_api.example
 }

--- a/examples/resources/fabric_kql_dashboard/outputs.tf
+++ b/examples/resources/fabric_kql_dashboard/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_kql_dashboard.example
+  value = fabric_kql_dashboard.example
 }

--- a/examples/resources/fabric_kql_database/outputs.tf
+++ b/examples/resources/fabric_kql_database/outputs.tf
@@ -1,34 +1,34 @@
 output "example1" {
-  value     = resource.fabric_kql_database.example1
+  value     = fabric_kql_database.example1
   sensitive = true
 }
 
 output "example2" {
-  value     = resource.fabric_kql_database.example2
+  value     = fabric_kql_database.example2
   sensitive = true
 }
 
 output "example3" {
-  value     = resource.fabric_kql_database.example3
+  value     = fabric_kql_database.example3
   sensitive = true
 }
 
 output "example4" {
-  value     = resource.fabric_kql_database.example4
+  value     = fabric_kql_database.example4
   sensitive = true
 }
 
 output "example5" {
-  value     = resource.fabric_kql_database.example5
+  value     = fabric_kql_database.example5
   sensitive = true
 }
 
 output "example6" {
-  value     = resource.fabric_kql_database.example6
+  value     = fabric_kql_database.example6
   sensitive = true
 }
 
 output "example7" {
-  value     = resource.fabric_kql_database.example7
+  value     = fabric_kql_database.example7
   sensitive = true
 }

--- a/examples/resources/fabric_kql_queryset/outputs.tf
+++ b/examples/resources/fabric_kql_queryset/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_kql_queryset.example
+  value = fabric_kql_queryset.example
 }

--- a/examples/resources/fabric_lakehouse/outputs.tf
+++ b/examples/resources/fabric_lakehouse/outputs.tf
@@ -1,7 +1,7 @@
 output "example1" {
-  value = resource.fabric_lakehouse.example1
+  value = fabric_lakehouse.example1
 }
 
 output "example2" {
-  value = resource.fabric_lakehouse.example2
+  value = fabric_lakehouse.example2
 }

--- a/examples/resources/fabric_mirrored_database/outputs.tf
+++ b/examples/resources/fabric_mirrored_database/outputs.tf
@@ -1,11 +1,11 @@
 output "example" {
-  value = resource.fabric_mirrored_database.example
+  value = fabric_mirrored_database.example
 }
 
 output "example_definition_bootstrap" {
-  value = resource.fabric_mirrored_database.example_definition_bootstrap
+  value = fabric_mirrored_database.example_definition_bootstrap
 }
 
 output "example_definition_update" {
-  value = resource.fabric_mirrored_database.example_definition_update
+  value = fabric_mirrored_database.example_definition_update
 }

--- a/examples/resources/fabric_ml_experiment/outputs.tf
+++ b/examples/resources/fabric_ml_experiment/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_ml_experiment.example
+  value = fabric_ml_experiment.example
 }

--- a/examples/resources/fabric_ml_model/outputs.tf
+++ b/examples/resources/fabric_ml_model/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_ml_model.example
+  value = fabric_ml_model.example
 }

--- a/examples/resources/fabric_notebook/outputs.tf
+++ b/examples/resources/fabric_notebook/outputs.tf
@@ -1,11 +1,11 @@
 output "example" {
-  value = resource.fabric_notebook.example
+  value = fabric_notebook.example
 }
 
 output "example_definition_bootstrap" {
-  value = resource.fabric_notebook.example_definition_bootstrap
+  value = fabric_notebook.example_definition_bootstrap
 }
 
 output "example_definition_update" {
-  value = resource.fabric_notebook.example_definition_update
+  value = fabric_notebook.example_definition_update
 }

--- a/examples/resources/fabric_report/outputs.tf
+++ b/examples/resources/fabric_report/outputs.tf
@@ -1,7 +1,7 @@
 output "example" {
-  value = resource.fabric_report.example_bootstrap
+  value = fabric_report.example_bootstrap
 }
 
 output "example_update" {
-  value = resource.fabric_report.example_update
+  value = fabric_report.example_update
 }

--- a/examples/resources/fabric_semantic_model/outputs.tf
+++ b/examples/resources/fabric_semantic_model/outputs.tf
@@ -1,7 +1,7 @@
 output "example" {
-  value = resource.fabric_semantic_model.example_bootstrap
+  value = fabric_semantic_model.example_bootstrap
 }
 
 output "example_update" {
-  value = resource.fabric_semantic_model.example_update
+  value = fabric_semantic_model.example_update
 }

--- a/examples/resources/fabric_spark_custom_pool/outputs.tf
+++ b/examples/resources/fabric_spark_custom_pool/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_spark_custom_pool.example
+  value = fabric_spark_custom_pool.example
 }

--- a/examples/resources/fabric_spark_environment_settings/outputs.tf
+++ b/examples/resources/fabric_spark_environment_settings/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_spark_environment_settings.example
+  value = fabric_spark_environment_settings.example
 }

--- a/examples/resources/fabric_spark_job_definition/outputs.tf
+++ b/examples/resources/fabric_spark_job_definition/outputs.tf
@@ -1,11 +1,11 @@
 output "example" {
-  value = resource.fabric_spark_job_definition.example
+  value = fabric_spark_job_definition.example
 }
 
 output "example_definition_bootstrap" {
-  value = resource.fabric_spark_job_definition.example_definition_bootstrap
+  value = fabric_spark_job_definition.example_definition_bootstrap
 }
 
 output "example_definition_update" {
-  value = resource.fabric_spark_job_definition.example_definition_update
+  value = fabric_spark_job_definition.example_definition_update
 }

--- a/examples/resources/fabric_spark_workspace_settings/outputs.tf
+++ b/examples/resources/fabric_spark_workspace_settings/outputs.tf
@@ -1,7 +1,7 @@
 output "example1" {
-  value = resource.fabric_spark_workspace_settings.example1
+  value = fabric_spark_workspace_settings.example1
 }
 
 output "example2" {
-  value = resource.fabric_spark_workspace_settings.example2
+  value = fabric_spark_workspace_settings.example2
 }

--- a/examples/resources/fabric_sql_database/outputs.tf
+++ b/examples/resources/fabric_sql_database/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_sql_database.example
+  value = fabric_sql_database.example
 }

--- a/examples/resources/fabric_warehouse/outputs.tf
+++ b/examples/resources/fabric_warehouse/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_warehouse.example
+  value = fabric_warehouse.example
 }

--- a/examples/resources/fabric_workspace/outputs.tf
+++ b/examples/resources/fabric_workspace/outputs.tf
@@ -1,7 +1,7 @@
 output "example1" {
-  value = resource.fabric_workspace.example1
+  value = fabric_workspace.example1
 }
 
 output "example2" {
-  value = resource.fabric_workspace.example2
+  value = fabric_workspace.example2
 }

--- a/examples/resources/fabric_workspace_git/outputs.tf
+++ b/examples/resources/fabric_workspace_git/outputs.tf
@@ -1,7 +1,7 @@
 output "azdo" {
-  value = resource.fabric_workspace_git.azdo
+  value = fabric_workspace_git.azdo
 }
 
 output "github" {
-  value = resource.fabric_workspace_git.github
+  value = fabric_workspace_git.github
 }

--- a/examples/resources/fabric_workspace_role_assignment/outputs.tf
+++ b/examples/resources/fabric_workspace_role_assignment/outputs.tf
@@ -1,3 +1,3 @@
 output "example" {
-  value = resource.fabric_workspace_role_assignment.example
+  value = fabric_workspace_role_assignment.example
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes updates to several Terraform output files to simplify the resource references. The changes remove the `resource.` prefix from the values.