### PR TITLE
refactor: prefer sets over lists

### DIFF
--- a/docs/data-sources/activators.md
+++ b/docs/data-sources/activators.md
@@ -40,7 +40,7 @@ data "fabric_activators" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Activators. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Activators. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/capacities.md
+++ b/docs/data-sources/capacities.md
@@ -31,7 +31,7 @@ data "fabric_capacities" "example" {}
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Capacities. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Capacities. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/dashboards.md
+++ b/docs/data-sources/dashboards.md
@@ -37,7 +37,7 @@ data "fabric_dashboards" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Dashboards. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Dashboards. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/data_pipelines.md
+++ b/docs/data-sources/data_pipelines.md
@@ -40,7 +40,7 @@ data "fabric_data_pipelines" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Data Pipelines. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Data Pipelines. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/datamarts.md
+++ b/docs/data-sources/datamarts.md
@@ -37,7 +37,7 @@ data "fabric_datamarts" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Datamarts. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Datamarts. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -31,7 +31,7 @@ data "fabric_domains" "example" {}
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Domains. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Domains. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -37,7 +37,7 @@ data "fabric_environments" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Environments. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Environments. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/eventhouse.md
+++ b/docs/data-sources/eventhouse.md
@@ -103,6 +103,6 @@ Use [`provider::fabric::content_decode`](../functions/content_decode.md) functio
 
 Read-Only:
 
-- `database_ids` (List of String) List of all KQL Database children IDs.
+- `database_ids` (Set of String) List of all KQL Database children IDs.
 - `ingestion_service_uri` (String) Ingestion service URI.
 - `query_service_uri` (String) Query service URI.

--- a/docs/data-sources/eventhouses.md
+++ b/docs/data-sources/eventhouses.md
@@ -37,7 +37,7 @@ data "fabric_eventhouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Eventhouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Eventhouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 
@@ -65,6 +65,6 @@ Read-Only:
 
 Read-Only:
 
-- `database_ids` (List of String) List of all KQL Database children IDs.
+- `database_ids` (Set of String) List of all KQL Database children IDs.
 - `ingestion_service_uri` (String) Ingestion service URI.
 - `query_service_uri` (String) Query service URI.

--- a/docs/data-sources/eventstreams.md
+++ b/docs/data-sources/eventstreams.md
@@ -40,7 +40,7 @@ data "fabric_eventstreams" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Eventstreams. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Eventstreams. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/graphql_apis.md
+++ b/docs/data-sources/graphql_apis.md
@@ -40,7 +40,7 @@ data "fabric_graphql_apis" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of GraphQL APIs. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of GraphQL APIs. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/kql_dashboards.md
+++ b/docs/data-sources/kql_dashboards.md
@@ -37,7 +37,7 @@ data "fabric_kql_dashboards" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of KQL Dashboards. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of KQL Dashboards. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/kql_databases.md
+++ b/docs/data-sources/kql_databases.md
@@ -37,7 +37,7 @@ data "fabric_kql_databases" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of KQL Databases. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of KQL Databases. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/kql_querysets.md
+++ b/docs/data-sources/kql_querysets.md
@@ -40,7 +40,7 @@ data "fabric_kql_querysets" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of KQL Querysets. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of KQL Querysets. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/lakehouses.md
+++ b/docs/data-sources/lakehouses.md
@@ -34,7 +34,7 @@ data "fabric_lakehouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Lakehouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Lakehouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/mirrored_databases.md
+++ b/docs/data-sources/mirrored_databases.md
@@ -37,7 +37,7 @@ data "fabric_mirrored_databases" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Mirrored Databases. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Mirrored Databases. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/mirrored_warehouses.md
+++ b/docs/data-sources/mirrored_warehouses.md
@@ -40,7 +40,7 @@ data "fabric_mirrored_warehouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Mirrored Warehouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Mirrored Warehouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/ml_experiments.md
+++ b/docs/data-sources/ml_experiments.md
@@ -40,7 +40,7 @@ data "fabric_ml_experiments" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of ML Experiments. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of ML Experiments. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/ml_models.md
+++ b/docs/data-sources/ml_models.md
@@ -40,7 +40,7 @@ data "fabric_ml_models" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of ML Models. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of ML Models. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/notebooks.md
+++ b/docs/data-sources/notebooks.md
@@ -37,7 +37,7 @@ data "fabric_notebooks" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Notebooks. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Notebooks. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/paginated_reports.md
+++ b/docs/data-sources/paginated_reports.md
@@ -40,7 +40,7 @@ data "fabric_paginated_reports" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Paginated Reports. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Paginated Reports. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/reports.md
+++ b/docs/data-sources/reports.md
@@ -37,7 +37,7 @@ data "fabric_reports" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Reports. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Reports. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/semantic_models.md
+++ b/docs/data-sources/semantic_models.md
@@ -37,7 +37,7 @@ data "fabric_semantic_models" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Semantic Models. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Semantic Models. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/spark_job_definitions.md
+++ b/docs/data-sources/spark_job_definitions.md
@@ -37,7 +37,7 @@ data "fabric_spark_job_definitions" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Spark Job Definitions. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Spark Job Definitions. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/sql_databases.md
+++ b/docs/data-sources/sql_databases.md
@@ -40,7 +40,7 @@ data "fabric_sql_databases" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of SQL Databases. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of SQL Databases. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/sql_endpoints.md
+++ b/docs/data-sources/sql_endpoints.md
@@ -40,7 +40,7 @@ data "fabric_sql_endpoints" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of SQL Endpoints. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of SQL Endpoints. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/warehouses.md
+++ b/docs/data-sources/warehouses.md
@@ -37,7 +37,7 @@ data "fabric_warehouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes List) The list of Warehouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The list of Warehouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ You can find more information on how to do this in the following guides:
 
 ### Optional
 
-- `auxiliary_tenant_ids` (List of String) The Auxiliary Tenant IDs which should be used.
+- `auxiliary_tenant_ids` (Set of String) The Auxiliary Tenant IDs which should be used.
 - `azure_devops_service_connection_id` (String) The Azure DevOps Service Connection ID that uses Workload Identity Federation.
 - `client_certificate` (String, Sensitive) Base64 encoded PKCS#12 certificate bundle. For use when authenticating as a Service Principal using a Client Certificate.
 - `client_certificate_file_path` (String) The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service Principal using a Client Certificate.

--- a/docs/resources/eventhouse.md
+++ b/docs/resources/eventhouse.md
@@ -134,7 +134,7 @@ Optional:
 
 Read-Only:
 
-- `database_ids` (List of String) List of all KQL Database children IDs.
+- `database_ids` (Set of String) List of all KQL Database children IDs.
 - `ingestion_service_uri` (String) Ingestion service URI.
 - `query_service_uri` (String) Query service URI.
 

--- a/internal/pkg/fabricitem/data_items.go
+++ b/internal/pkg/fabricitem/data_items.go
@@ -55,10 +55,10 @@ func (d *DataSourceFabricItems) Schema(ctx context.Context, _ datasource.SchemaR
 				Required:            true,
 				CustomType:          customtypes.UUIDType{},
 			},
-			"values": schema.ListNestedAttribute{
+			"values": schema.SetNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: fmt.Sprintf("The list of %s.", d.Names),
-				CustomType:          supertypes.NewListNestedObjectTypeOf[fabricItemModel](ctx),
+				CustomType:          supertypes.NewSetNestedObjectTypeOf[fabricItemModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"workspace_id": schema.StringAttribute{

--- a/internal/pkg/fabricitem/data_items_properties.go
+++ b/internal/pkg/fabricitem/data_items_properties.go
@@ -73,10 +73,10 @@ func (d *DataSourceFabricItemsProperties[Ttfprop, Titemprop]) Schema(ctx context
 				Required:            true,
 				CustomType:          customtypes.UUIDType{},
 			},
-			"values": schema.ListNestedAttribute{
+			"values": schema.SetNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: fmt.Sprintf("The list of %s.", d.Names),
-				CustomType:          supertypes.NewListNestedObjectTypeOf[FabricItemPropertiesModel[Ttfprop, Titemprop]](ctx),
+				CustomType:          supertypes.NewSetNestedObjectTypeOf[FabricItemPropertiesModel[Ttfprop, Titemprop]](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: attributes,
 				},

--- a/internal/pkg/fabricitem/models_data_items.go
+++ b/internal/pkg/fabricitem/models_data_items.go
@@ -15,9 +15,9 @@ import (
 )
 
 type dataSourceFabricItemsModel struct {
-	WorkspaceID customtypes.UUID                                    `tfsdk:"workspace_id"`
-	Values      supertypes.ListNestedObjectValueOf[fabricItemModel] `tfsdk:"values"`
-	Timeouts    timeouts.Value                                      `tfsdk:"timeouts"`
+	WorkspaceID customtypes.UUID                                   `tfsdk:"workspace_id"`
+	Values      supertypes.SetNestedObjectValueOf[fabricItemModel] `tfsdk:"values"`
+	Timeouts    timeouts.Value                                     `tfsdk:"timeouts"`
 }
 
 func (to *dataSourceFabricItemsModel) setValues(ctx context.Context, from []fabcore.Item) diag.Diagnostics {

--- a/internal/pkg/fabricitem/models_data_items_properties.go
+++ b/internal/pkg/fabricitem/models_data_items_properties.go
@@ -14,9 +14,9 @@ import (
 )
 
 type DataSourceFabricItemsPropertiesModel[Ttfprop, Titemprop any] struct {
-	WorkspaceID customtypes.UUID                                                                  `tfsdk:"workspace_id"`
-	Values      supertypes.ListNestedObjectValueOf[FabricItemPropertiesModel[Ttfprop, Titemprop]] `tfsdk:"values"`
-	Timeouts    timeouts.Value                                                                    `tfsdk:"timeouts"`
+	WorkspaceID customtypes.UUID                                                                 `tfsdk:"workspace_id"`
+	Values      supertypes.SetNestedObjectValueOf[FabricItemPropertiesModel[Ttfprop, Titemprop]] `tfsdk:"values"`
+	Timeouts    timeouts.Value                                                                   `tfsdk:"timeouts"`
 }
 
 func (to *DataSourceFabricItemsPropertiesModel[Ttfprop, Titemprop]) setValues(

--- a/internal/provider/config/model.go
+++ b/internal/provider/config/model.go
@@ -32,7 +32,7 @@ type ProviderConfigModel struct {
 	Timeout                        timetypes.GoDuration `tfsdk:"timeout"`
 	Endpoint                       customtypes.URL      `tfsdk:"endpoint"`
 	Environment                    types.String         `tfsdk:"environment"`
-	AuxiliaryTenantIDs             types.List           `tfsdk:"auxiliary_tenant_ids"`
+	AuxiliaryTenantIDs             types.Set            `tfsdk:"auxiliary_tenant_ids"`
 	TenantID                       customtypes.UUID     `tfsdk:"tenant_id"`
 	ClientID                       customtypes.UUID     `tfsdk:"client_id"`
 	ClientIDFilePath               types.String         `tfsdk:"client_id_file_path"`

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -225,12 +225,12 @@ func (p *FabricProvider) Schema(ctx context.Context, _ provider.SchemaRequest, r
 				Optional:            true,
 				CustomType:          customtypes.UUIDType{},
 			},
-			"auxiliary_tenant_ids": schema.ListAttribute{
+			"auxiliary_tenant_ids": schema.SetAttribute{
 				MarkdownDescription: "The Auxiliary Tenant IDs which should be used.",
 				ElementType:         customtypes.UUIDType{},
 				Optional:            true,
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(3),
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(3),
 				},
 			},
 

--- a/internal/provider/utils/envvars.go
+++ b/internal/provider/utils/envvars.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func GetListStringValues(value types.List, envVarKeys, defaultValue []string) types.List {
+func GetListStringValues(value types.Set, envVarKeys, defaultValue []string) types.Set {
 	if value.IsUnknown() || value.IsNull() {
 		values := []attr.Value{}
 
@@ -26,7 +26,7 @@ func GetListStringValues(value types.List, envVarKeys, defaultValue []string) ty
 			}
 		}
 
-		return types.ListValueMust(types.StringType, values)
+		return types.SetValueMust(types.StringType, values)
 	}
 
 	return value

--- a/internal/services/activator/data_activators_test.go
+++ b/internal/services/activator/data_activators_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_ActivatorsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/capacity/data_capacities.go
+++ b/internal/services/capacity/data_capacities.go
@@ -42,10 +42,10 @@ func (d *dataSourceCapacities) Schema(ctx context.Context, _ datasource.SchemaRe
 			"Use this data source to list [" + ItemsName + "](" + ItemDocsURL + ") for more information.\n\n" +
 			ItemDocsSPNSupport,
 		Attributes: map[string]schema.Attribute{
-			"values": schema.ListNestedAttribute{
+			"values": schema.SetNestedAttribute{
 				MarkdownDescription: fmt.Sprintf("The list of %s.", ItemsName),
 				Computed:            true,
-				CustomType:          supertypes.NewListNestedObjectTypeOf[baseCapacityModel](ctx),
+				CustomType:          supertypes.NewSetNestedObjectTypeOf[baseCapacityModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{

--- a/internal/services/capacity/data_capacities_test.go
+++ b/internal/services/capacity/data_capacities_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp/fakes"
@@ -43,9 +46,18 @@ func TestUnit_CapacitiesDataSource(t *testing.T) {
 				testDataSourceItemsHeader,
 				map[string]any{},
 			),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
-			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/capacity/models_data_capacities.go
+++ b/internal/services/capacity/models_data_capacities.go
@@ -13,8 +13,8 @@ import (
 )
 
 type dataSourceCapacitiesModel struct {
-	Values   supertypes.ListNestedObjectValueOf[baseCapacityModel] `tfsdk:"values"`
-	Timeouts timeouts.Value                                        `tfsdk:"timeouts"`
+	Values   supertypes.SetNestedObjectValueOf[baseCapacityModel] `tfsdk:"values"`
+	Timeouts timeouts.Value                                       `tfsdk:"timeouts"`
 }
 
 func (to *dataSourceCapacitiesModel) setValues(ctx context.Context, from []fabcore.Capacity) diag.Diagnostics {

--- a/internal/services/dashboard/data_dashboards_test.go
+++ b/internal/services/dashboard/data_dashboards_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/common"
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
@@ -66,8 +69,20 @@ func TestUnit_DashboardsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/datamart/data_datamarts_test.go
+++ b/internal/services/datamart/data_datamarts_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_DatamartsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/datapipeline/data_data_pipelines_test.go
+++ b/internal/services/datapipeline/data_data_pipelines_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_DataPipelinesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/domain/data_domains.go
+++ b/internal/services/domain/data_domains.go
@@ -46,10 +46,10 @@ func (d *dataSourceDomains) Schema(ctx context.Context, _ datasource.SchemaReque
 	resp.Schema = schema.Schema{
 		MarkdownDescription: s.GetMarkdownDescription(),
 		Attributes: map[string]schema.Attribute{
-			"values": schema.ListNestedAttribute{
+			"values": schema.SetNestedAttribute{
 				MarkdownDescription: "The list of " + d.TypeInfo.Names + ".",
 				Computed:            true,
-				CustomType:          supertypes.NewListNestedObjectTypeOf[baseDomainModel](ctx),
+				CustomType:          supertypes.NewSetNestedObjectTypeOf[baseDomainModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: s.Attributes,
 				},

--- a/internal/services/domain/data_domains_test.go
+++ b/internal/services/domain/data_domains_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/common"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -41,9 +44,19 @@ func TestUnit_DomainsDataSource(t *testing.T) {
 				testDataSourceItemsHeader,
 				map[string]any{},
 			),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.id"),
-			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/domain/models.go
+++ b/internal/services/domain/models.go
@@ -50,8 +50,8 @@ DATA-SOURCE (list)
 */
 
 type dataSourceDomainsModel struct {
-	Values   supertypes.ListNestedObjectValueOf[baseDomainModel] `tfsdk:"values"`
-	Timeouts timeoutsD.Value                                     `tfsdk:"timeouts"`
+	Values   supertypes.SetNestedObjectValueOf[baseDomainModel] `tfsdk:"values"`
+	Timeouts timeoutsD.Value                                    `tfsdk:"timeouts"`
 }
 
 func (to *dataSourceDomainsModel) setValues(ctx context.Context, from []fabadmin.Domain) diag.Diagnostics {

--- a/internal/services/environment/data_environments_test.go
+++ b/internal/services/environment/data_environments_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,11 +71,23 @@ func TestUnit_EnvironmentsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.publish_details.state"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.publish_details.component_publish_info.spark_libraries.state"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.publish_details.component_publish_info.spark_settings.state"),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/eventhouse/data_eventhouses_test.go
+++ b/internal/services/eventhouse/data_eventhouses_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,11 +71,23 @@ func TestUnit_EventhousesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.query_service_uri"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.ingestion_service_uri"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.database_ids.0"),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/eventhouse/models.go
+++ b/internal/services/eventhouse/models.go
@@ -12,13 +12,13 @@ import (
 )
 
 type eventhousePropertiesModel struct {
-	IngestionServiceURI types.String                   `tfsdk:"ingestion_service_uri"`
-	QueryServiceURI     types.String                   `tfsdk:"query_service_uri"`
-	DatabaseIDs         supertypes.ListValueOf[string] `tfsdk:"database_ids"`
+	IngestionServiceURI types.String                  `tfsdk:"ingestion_service_uri"`
+	QueryServiceURI     types.String                  `tfsdk:"query_service_uri"`
+	DatabaseIDs         supertypes.SetValueOf[string] `tfsdk:"database_ids"`
 }
 
 func (to *eventhousePropertiesModel) set(ctx context.Context, from *fabeventhouse.Properties) {
 	to.IngestionServiceURI = types.StringPointerValue(from.IngestionServiceURI)
 	to.QueryServiceURI = types.StringPointerValue(from.QueryServiceURI)
-	to.DatabaseIDs = supertypes.NewListValueOfSlice(ctx, from.DatabasesItemIDs)
+	to.DatabaseIDs = supertypes.NewSetValueOfSlice(ctx, from.DatabasesItemIDs)
 }

--- a/internal/services/eventhouse/schema_data_eventhouse.go
+++ b/internal/services/eventhouse/schema_data_eventhouse.go
@@ -20,10 +20,10 @@ func getDataSourceEventhousePropertiesAttributes(ctx context.Context) map[string
 			MarkdownDescription: "Query service URI.",
 			Computed:            true,
 		},
-		"database_ids": schema.ListAttribute{
+		"database_ids": schema.SetAttribute{
 			MarkdownDescription: "List of all KQL Database children IDs.",
 			Computed:            true,
-			CustomType:          supertypes.NewListTypeOf[string](ctx),
+			CustomType:          supertypes.NewSetTypeOf[string](ctx),
 		},
 	}
 

--- a/internal/services/eventhouse/schema_resource_eventhouse.go
+++ b/internal/services/eventhouse/schema_resource_eventhouse.go
@@ -27,10 +27,10 @@ func getResourceEventhousePropertiesAttributes(ctx context.Context) map[string]s
 			MarkdownDescription: "Query service URI.",
 			Computed:            true,
 		},
-		"database_ids": schema.ListAttribute{
+		"database_ids": schema.SetAttribute{
 			MarkdownDescription: "List of all KQL Database children IDs.",
 			Computed:            true,
-			CustomType:          supertypes.NewListTypeOf[string](ctx),
+			CustomType:          supertypes.NewSetTypeOf[string](ctx),
 		},
 	}
 

--- a/internal/services/eventstream/data_eventstreams_test.go
+++ b/internal/services/eventstream/data_eventstreams_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_EventstreamsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/graphqlapi/data_graphql_apis_test.go
+++ b/internal/services/graphqlapi/data_graphql_apis_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_GraphQLApisDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/kqldashboard/data_kql_dashboards_test.go
+++ b/internal/services/kqldashboard/data_kql_dashboards_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_KQLDashboardsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/kqldatabase/data_kql_databases_test.go
+++ b/internal/services/kqldatabase/data_kql_databases_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_KQLDatabasesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/kqlqueryset/data_kql_querysets_test.go
+++ b/internal/services/kqlqueryset/data_kql_querysets_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_KQLQuerysetsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/lakehouse/data_lakehouses_test.go
+++ b/internal/services/lakehouse/data_lakehouses_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/common"
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
@@ -66,8 +69,20 @@ func TestUnit_LakehousesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/mirroreddatabase/data_mirrored_databases_test.go
+++ b/internal/services/mirroreddatabase/data_mirrored_databases_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,13 +71,25 @@ func TestUnit_MirroredDatabasesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.default_schema"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.onelake_tables_path"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.sql_endpoint_properties.connection_string"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.sql_endpoint_properties.id"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.sql_endpoint_properties.provisioning_status"),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/mirroredwarehouse/data_mirrored_warehouses_test.go
+++ b/internal/services/mirroredwarehouse/data_mirrored_warehouses_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_MirroredWarehousesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/mlexperiment/data_ml_experiments_test.go
+++ b/internal/services/mlexperiment/data_ml_experiments_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_MLExperimentsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/mlmodel/data_ml_models_test.go
+++ b/internal/services/mlmodel/data_ml_models_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_MLModelsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/notebook/data_notebooks_test.go
+++ b/internal/services/notebook/data_notebooks_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_NotebooksDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/paginatedreport/data_paginated_reports_test.go
+++ b/internal/services/paginatedreport/data_paginated_reports_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_PaginatedReportsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/report/data_reports_test.go
+++ b/internal/services/report/data_reports_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_ReportsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/semanticmodel/data_semantic_models_test.go
+++ b/internal/services/semanticmodel/data_semantic_models_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_SemanticModelsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/sparkjobdefinition/data_spark_job_definitions_test.go
+++ b/internal/services/sparkjobdefinition/data_spark_job_definitions_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,9 +71,21 @@ func TestUnit_SparkJobDefinitionsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.onelake_root_path"),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/sqldatabase/data_sql_databases_test.go
+++ b/internal/services/sqldatabase/data_sql_databases_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_SQLDatabasesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/sqlendpoint/data_sql_endpoints_test.go
+++ b/internal/services/sqlendpoint/data_sql_endpoints_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,8 +71,20 @@ func TestUnit_SQLEndpointsDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/warehouse/data_warehouses_test.go
+++ b/internal/services/warehouse/data_warehouses_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/framework/customtypes"
 	"github.com/microsoft/terraform-provider-fabric/internal/testhelp"
@@ -68,11 +71,23 @@ func TestUnit_WarehousesDataSource(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "workspace_id", entity.WorkspaceID),
-				resource.TestCheckResourceAttrPtr(testDataSourceItemsFQN, "values.1.id", entity.ID),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.connection_string"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.created_date"),
 				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.properties.last_updated_time"),
 			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }

--- a/internal/services/workspace/data_workspaces_test.go
+++ b/internal/services/workspace/data_workspaces_test.go
@@ -9,6 +9,9 @@ import (
 
 	at "github.com/dcarbone/terraform-plugin-framework-utils/v3/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	fabcore "github.com/microsoft/fabric-sdk-go/fabric/core"
 
 	"github.com/microsoft/terraform-provider-fabric/internal/common"
@@ -44,9 +47,19 @@ func TestUnit_WorkspacesDataSource(t *testing.T) {
 				testDataSourceItemsHeader,
 				map[string]any{},
 			),
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttrSet(testDataSourceItemsFQN, "values.1.id"),
-			),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue(
+					testDataSourceItemsFQN,
+					tfjsonpath.New("values"),
+					knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"id":           knownvalue.StringExact(*entity.ID),
+							"display_name": knownvalue.StringExact(*entity.DisplayName),
+							"description":  knownvalue.StringExact(*entity.Description),
+						}),
+					}),
+				),
+			},
 		},
 	}))
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Prefer sets over lists.

Use Lists sparingly and only when order or duplication matters, which is rare for Fabric resources - currently does not exist.