### PR TITLE
chore: repo hygiene, devex enhancement

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -30,6 +30,9 @@ kinds:
   - label: 🚨 Security
     key: security
     auto: patch
+  - label: 📚 Documentation
+    key: documentation
+    auto: patch
 newlines:
   afterChangelogHeader: 1
   beforeChangelogVersion: 1

--- a/.devcontainer/features/tfprovider-local-dev/install.sh
+++ b/.devcontainer/features/tfprovider-local-dev/install.sh
@@ -4,15 +4,15 @@ set -e
 export DEBIAN_FRONTEND="noninteractive"
 
 if [ -n "$SUDO_USER" ]; then
-	HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+  HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
 fi
 
 # Variables
 # shellcheck disable=SC2153
 PROVIDER_NAME=${PROVIDERNAME}
 if [ -z "$PROVIDER_NAME" ]; then
-	echo "The 'providerName' is not set"
-	exit 1
+  echo "The 'providerName' is not set"
+  exit 1
 fi
 echo "PROVIDER_NAME is: $PROVIDER_NAME"
 
@@ -27,46 +27,46 @@ echo "SCRIPT_PATH is: $SCRIPT_PATH"
 
 USER="$_REMOTE_USER"
 if [ -n "$WSL_INTEROP" ] || [ -n "$WSL_DISTRO_NAME" ]; then
-	USER=${SUDO_USER:-$(whoami)}
+  USER=${SUDO_USER:-$(whoami)}
 fi
 echo "USER is: $USER"
 
 set_ownership_to_current_user() {
-	target_path=$1
-	if [ -d "$target_path" ]; then
-		chown -R "$USER" "$target_path"
-	fi
+  target_path=$1
+  if [ -d "$target_path" ]; then
+    chown -R "$USER" "$target_path"
+  fi
 }
 
 set_terraformrc() {
-	target_path=$1
+  target_path=$1
 
-	os_type=$(uname)
-	os_type=${os_type,,}
+  os_type=$(uname)
+  os_type=${os_type,,}
 
-	os_arch=$(uname -m)
-	if echo "$os_arch" | grep -E -q 'x86_64|amd64'; then
-		os_arch="amd64"
-	elif echo "$os_arch" | grep -E -q 'i386|i686'; then
-		os_arch="386"
-	elif echo "$os_arch" | grep -E -q 'aarch64|arm64'; then
-		os_arch="arm64"
-	elif echo "$os_arch" | grep -E -q 'armv'; then
-		os_arch="arm"
-	else
-		echo "Unsupported architecture"
-		exit 1
-	fi
+  os_arch=$(uname -m)
+  if echo "$os_arch" | grep -E -q 'x86_64|amd64'; then
+    os_arch="amd64"
+  elif echo "$os_arch" | grep -E -q 'i386|i686'; then
+    os_arch="386"
+  elif echo "$os_arch" | grep -E -q 'aarch64|arm64'; then
+    os_arch="arm64"
+  elif echo "$os_arch" | grep -E -q 'armv'; then
+    os_arch="arm"
+  else
+    echo "Unsupported architecture"
+    exit 1
+  fi
 
-	sed <"$SCRIPT_PATH/terraformrc.tmpl" -e "s|{{PROVIDER_NAME}}|${PROVIDER_NAME}|g" -e "s|{{PROVIDER_BIN_PATH}}|${WORKSPACE_PATH}/bin/${os_type}-${os_arch}|g" >"$target_path"
+  sed <"$SCRIPT_PATH/terraformrc.tmpl" -e "s|{{PROVIDER_NAME}}|${PROVIDER_NAME}|g" -e "s|{{PROVIDER_BIN_PATH}}|${WORKSPACE_PATH}/bin/${os_type}-${os_arch}|g" >"$target_path"
 }
 
 install() {
-	TFRC_PATH="$USER_HOME/.terraformrc"
-	set_terraformrc "$TFRC_PATH"
-	set_ownership_to_current_user "$TFRC_PATH"
-	set_ownership_to_current_user "$WORKSPACE_PATH"
-	set_ownership_to_current_user "$(go env GOPATH)"
+  TFRC_PATH="$USER_HOME/.terraformrc"
+  set_terraformrc "$TFRC_PATH"
+  set_ownership_to_current_user "$TFRC_PATH"
+  set_ownership_to_current_user "$WORKSPACE_PATH"
+  set_ownership_to_current_user "$(go env GOPATH)"
 }
 
 install

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,5 @@
-# Set default behaviour to automatically normalize line endings.
-* text=auto
-
-# Declare files that will always have LF line endings on checkout.
-*.sh text eol=lf
-*.go text eol=lf
+# Force the following filetypes to have unix eols, so Windows does not break them
+* text eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 *.{cmd,[cC][mM][dD]} text eol=crlf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     labels:
       - "deps/github-actions"
       - dependencies
+    groups:
+      all:
+        patterns: ["*"]
 
   - package-ecosystem: devcontainers
     directory: /
@@ -39,3 +42,23 @@ updates:
     labels:
       - "deps/go"
       - dependencies
+    groups:
+      all:
+        patterns: ["*"]
+
+  - package-ecosystem: terraform
+    directories:
+      - "/examples/resources/*"
+      - "/examples/data-sources/*"
+      - "/examples/provider/*"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - "deps/terraform"
+      - dependencies
+    groups:
+      all:
+        patterns: ["*"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,12 +72,12 @@
     "github.com/microsoft/terraform-provider-fabric"
   ],
   "go.diagnostic.vulncheck": "Imports",
-  "go.testTimeout": "3m",
-  // "go.lintTool": "golangci-lint",
-  // "go.lintFlags": [
-  //   "--fast",
-  //   "--fix"
-  // ],
+  "go.testTimeout": "5m",
+  "go.lintTool": "golangci-lint",
+  "go.lintFlags": [
+    "--fast",
+    "--fix"
+  ],
   // lint
   "linter.linters": {
     "yamllint": {

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,8 +1,8 @@
 {
-	"version": 1,
-	"metadata": {
-		"protocol_versions": [
-			"6.0"
-		]
-	}
+  "version": 1,
+  "metadata": {
+    "protocol_versions": [
+      "6.0"
+    ]
+  }
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several changes to configuration files to enhance documentation, update dependencies, and adjust settings for development tools. The most important changes include adding a new documentation label, modifying line ending settings, and updating dependabot configurations.

Configuration updates:

* [`.changie.yaml`](diffhunk://#diff-9f1c8d07b49e66598bb525c145a5d7524fef447d6993b72ccb378e70ebf922f3R33-R35): Added a new label for documentation changes to the `kinds` section.
* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eL1-R2): Adjusted line ending settings to ensure consistent handling of line endings across different operating systems.

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R18-R20): Added new groups for dependency updates and included configurations for Terraform dependencies. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R18-R20) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R45-R64)

Development tools settings:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L74-R79): Increased the Go test timeout to 5 minutes and re-enabled linting with `golangci-lint` and specific lint flags.