### PR TITLE
feat(logging): add support for custom allowed headers in sdk

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
       "env": {
         "FABRIC_PREVIEW": "true",
         "FABRIC_SDK_GO_LOGGING": "trace",
-        "FABRIC_SDK_GO_LOGGING_INCLUDE_BODY": "true"
+        "FABRIC_SDK_GO_LOGGING_INCLUDE_BODY": "true",
+        "FABRIC_SDK_GO_LOGGING_ALLOWED_HEADERS": "requestid;x-ms-operation-id;x-ms-public-api-error-code;home-cluster-uri;location;date;retry-after"
       },
       "args": [
         "-debug"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -64,7 +64,8 @@
     "TF_ACC": "1",
     "FABRIC_PREVIEW": "true",
     "FABRIC_SDK_GO_LOGGING": "trace",
-    "FABRIC_SDK_GO_LOGGING_INCLUDE_BODY": "true"
+    "FABRIC_SDK_GO_LOGGING_INCLUDE_BODY": "true",
+    "FABRIC_SDK_GO_LOGGING_ALLOWED_HEADERS": "requestid;x-ms-operation-id;x-ms-public-api-error-code;home-cluster-uri;location;date;retry-after"
   },
   "go.formatTool": "goimports",
   "go.formatFlags": [

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -163,6 +163,7 @@ func createDefaultClient(ctx context.Context, cfg *pconfig.ProviderConfig) (*fab
 
 			// Simple validation to prevent injection: only accept standard header format
 			headerRegex := regexp.MustCompile(`^[a-zA-Z0-9\-]+$`)
+
 			for _, header := range headers {
 				h := strings.ToLower(strings.TrimSpace(header))
 				if h != "" && headerRegex.MatchString(h) {


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Use env var instead of hard-coding

This pull request includes updates to the logging configuration and enhancements to the header validation process. The most important changes include adding a new environment variable for allowed headers, updating the logging configuration in the VSCode settings, and introducing header validation using regular expressions.

Logging configuration updates:

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L13-R14): Added the `FABRIC_SDK_GO_LOGGING_ALLOWED_HEADERS` environment variable to specify allowed headers for logging.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L67-R68): Added the `FABRIC_SDK_GO_LOGGING_ALLOWED_HEADERS` environment variable to specify allowed headers for logging.

Header validation enhancements:

* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R10): Imported the `regexp` package to support header validation.
* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L147-R183): Updated the `createDefaultClient` function to include validation for allowed headers using a regular expression, ensuring only standard header formats are accepted.
