### PR TITLE
feat(spark_workspace_settings): add option to manage default pool using id

### DIFF
--- a/.changes/unreleased/added-20250318-195402.yaml
+++ b/.changes/unreleased/added-20250318-195402.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: Option to manage "default pool" using pool ID in the `fabric_spark_workspace_settings` resource.
+time: 2025-03-18T19:54:02.3978618-07:00
+custom:
+    Issue: "111"

--- a/.changes/unreleased/added-20250318-195402.yaml
+++ b/.changes/unreleased/added-20250318-195402.yaml
@@ -2,4 +2,4 @@ kind: added
 body: Option to manage "default pool" using pool ID in the `fabric_spark_workspace_settings` resource.
 time: 2025-03-18T19:54:02.3978618-07:00
 custom:
-    Issue: "111"
+    Issue: "324"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -476,7 +476,13 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: 📥 Download
+      - name: 📥 Download test results
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
+        with:
+          pattern: terraform-1_11-test-results
+          merge-multiple: true
+
+      - name: 📥 Download test coverage results
         uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
         with:
           pattern: terraform-1_11-test-coverage*
@@ -485,7 +491,13 @@ jobs:
       - name: 📝 Publish
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
 
-      - name: 📤 Upload results to Codecov
+      - name: 📤 Upload test results to Codecov
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1.1.0
+        with:
+          use_oidc: true
+          files: ./testresults.xml
+
+      - name: 📤 Upload coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           use_oidc: true

--- a/docs/data-sources/spark_workspace_settings.md
+++ b/docs/data-sources/spark_workspace_settings.md
@@ -103,7 +103,7 @@ Read-Only:
 
 Read-Only:
 
-- `id` (String) The Pool ID.
+- `id` (String) The Pool ID. `00000000-0000-0000-0000-000000000000` means using the starter pool.
 - `name` (String) The Pool name. `Starter Pool` means using the starting pool.
 - `type` (String) The Pool type. Possible values: `Capacity`, `Workspace`.
 

--- a/docs/resources/spark_workspace_settings.md
+++ b/docs/resources/spark_workspace_settings.md
@@ -156,12 +156,9 @@ Optional:
 
 Optional:
 
-- `name` (String) The Pool name. It should be a valid custom pool name. `Starter Pool` means use starter pool.
+- `id` (String) The Pool ID. `00000000-0000-0000-0000-000000000000` means use the starter pool.
+- `name` (String) The Pool name. It should be a valid custom pool name. `Starter Pool` means use the starter pool.
 - `type` (String) The Pool type. Accepted values: `Capacity`, `Workspace`.
-
-Read-Only:
-
-- `id` (String) The Pool ID.
 
 <a id="nestedatt--pool--starter_pool"></a>
 

--- a/internal/services/spark/data_spark_workspace_settings.go
+++ b/internal/services/spark/data_spark_workspace_settings.go
@@ -122,7 +122,7 @@ func (d *dataSourceSparkWorkspaceSettings) Schema(ctx context.Context, _ datasou
 						CustomType:          supertypes.NewSingleNestedObjectTypeOf[defaultPoolPropertiesModel](ctx),
 						Attributes: map[string]schema.Attribute{
 							"id": schema.StringAttribute{
-								MarkdownDescription: "The Pool ID.",
+								MarkdownDescription: "The Pool ID. `00000000-0000-0000-0000-000000000000` means using the starter pool.",
 								Computed:            true,
 								CustomType:          customtypes.UUIDType{},
 							},

--- a/internal/services/spark/models_spark_workspace_settings.go
+++ b/internal/services/spark/models_spark_workspace_settings.go
@@ -306,11 +306,19 @@ func (to *requestUpdateSparkWorkspaceSettings) set(ctx context.Context, from res
 				return diags
 			}
 
+			var reqDefaultPool fabspark.InstancePool
+
+			if !defaultPool.ID.IsNull() && !defaultPool.ID.IsUnknown() {
+				reqDefaultPool.ID = defaultPool.ID.ValueStringPointer()
+			}
+
 			if !defaultPool.Name.IsNull() && !defaultPool.Name.IsUnknown() {
-				reqPool.DefaultPool = &fabspark.InstancePool{
-					Name: defaultPool.Name.ValueStringPointer(),
-					Type: (*fabspark.CustomPoolType)(defaultPool.Type.ValueStringPointer()),
-				}
+				reqDefaultPool.Name = defaultPool.Name.ValueStringPointer()
+				reqDefaultPool.Type = (*fabspark.CustomPoolType)(defaultPool.Type.ValueStringPointer())
+			}
+
+			if reqDefaultPool != (fabspark.InstancePool{}) {
+				reqPool.DefaultPool = &reqDefaultPool
 			}
 		}
 

--- a/internal/services/spark/resource_spark_workspace_settings.go
+++ b/internal/services/spark/resource_spark_workspace_settings.go
@@ -206,15 +206,22 @@ func (r *resourceSparkWorkspaceSettings) Schema(ctx context.Context, _ resource.
 						},
 						Attributes: map[string]schema.Attribute{
 							"id": schema.StringAttribute{
-								MarkdownDescription: "The Pool ID.",
+								MarkdownDescription: "The Pool ID. `00000000-0000-0000-0000-000000000000` means use the starter pool.",
+								Optional:            true,
 								Computed:            true,
 								CustomType:          customtypes.UUIDType{},
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.UseStateForUnknown(),
 								},
+								Validators: []validator.String{
+									stringvalidator.ConflictsWith(
+										path.MatchRelative().AtParent().AtName("name"),
+										path.MatchRelative().AtParent().AtName("type"),
+									),
+								},
 							},
 							"name": schema.StringAttribute{
-								MarkdownDescription: "The Pool name. It should be a valid custom pool name. `Starter Pool` means use starter pool.",
+								MarkdownDescription: "The Pool name. It should be a valid custom pool name. `Starter Pool` means use the starter pool.",
 								Optional:            true,
 								Computed:            true,
 								PlanModifiers: []planmodifier.String{
@@ -222,6 +229,7 @@ func (r *resourceSparkWorkspaceSettings) Schema(ctx context.Context, _ resource.
 								},
 								Validators: []validator.String{
 									stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("type")),
+									stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("id")),
 								},
 							},
 							"type": schema.StringAttribute{
@@ -233,6 +241,7 @@ func (r *resourceSparkWorkspaceSettings) Schema(ctx context.Context, _ resource.
 								},
 								Validators: []validator.String{
 									stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("name")),
+									stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("id")),
 									stringvalidator.OneOf(utils.ConvertEnumsToStringSlices(fabspark.PossibleCustomPoolTypeValues(), false)...),
 								},
 							},

--- a/internal/services/spark/resource_spark_workspace_settings_test.go
+++ b/internal/services/spark/resource_spark_workspace_settings_test.go
@@ -91,8 +91,10 @@ func TestAcc_SparkWorkspaceSettingsResource_CRUD(t *testing.T) {
 						"automatic_log": map[string]any{
 							"enabled": true,
 						},
-						"default_pool": map[string]any{
-							"id": "00000000-0000-0000-0000-000000000000",
+						"pool": map[string]any{
+							"default_pool": map[string]any{
+								"id": "00000000-0000-0000-0000-000000000000",
+							},
 						},
 					},
 				)),
@@ -114,8 +116,11 @@ func TestAcc_SparkWorkspaceSettingsResource_CRUD(t *testing.T) {
 						"automatic_log": map[string]any{
 							"enabled": true,
 						},
-						"default_pool": map[string]any{
-							"name": "Starter Pool",
+						"pool": map[string]any{
+							"default_pool": map[string]any{
+								"name": "Starter Pool",
+								"type": "Workspace",
+							},
 						},
 					},
 				)),

--- a/internal/services/spark/resource_spark_workspace_settings_test.go
+++ b/internal/services/spark/resource_spark_workspace_settings_test.go
@@ -79,6 +79,52 @@ func TestAcc_SparkWorkspaceSettingsResource_CRUD(t *testing.T) {
 				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "automatic_log.enabled", "true"),
 			),
 		},
+		// Update and Read
+		{
+			ResourceName: testResourceSparkWorkspaceSettingsFQN,
+			Config: at.JoinConfigs(
+				workspaceResourceHCL,
+				at.CompileConfig(
+					testResourceSparkWorkspaceSettingsHeader,
+					map[string]any{
+						"workspace_id": testhelp.RefByFQN(workspaceResourceFQN, "id"),
+						"automatic_log": map[string]any{
+							"enabled": true,
+						},
+						"default_pool": map[string]any{
+							"id": "00000000-0000-0000-0000-000000000000",
+						},
+					},
+				)),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "pool.default_pool.id", "00000000-0000-0000-0000-000000000000"),
+				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "pool.default_pool.name", "Starter Pool"),
+				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "automatic_log.enabled", "true"),
+			),
+		},
+		// Update and Read
+		{
+			ResourceName: testResourceSparkWorkspaceSettingsFQN,
+			Config: at.JoinConfigs(
+				workspaceResourceHCL,
+				at.CompileConfig(
+					testResourceSparkWorkspaceSettingsHeader,
+					map[string]any{
+						"workspace_id": testhelp.RefByFQN(workspaceResourceFQN, "id"),
+						"automatic_log": map[string]any{
+							"enabled": true,
+						},
+						"default_pool": map[string]any{
+							"name": "Starter Pool",
+						},
+					},
+				)),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "pool.default_pool.id", "00000000-0000-0000-0000-000000000000"),
+				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "pool.default_pool.name", "Starter Pool"),
+				resource.TestCheckResourceAttr(testResourceSparkWorkspaceSettingsFQN, "automatic_log.enabled", "true"),
+			),
+		},
 	},
 	))
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request introduces an option to manage the "default pool" using the pool ID in the `fabric_spark_workspace_settings` resource. The changes span documentation updates, schema modifications, and test enhancements.