### PR TITLE
fix(eventstream): missing eventstreamProperties.json definition path

### DIFF
--- a/.changes/unreleased/fixed-20250319-005743.yaml
+++ b/.changes/unreleased/fixed-20250319-005743.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Added missing `eventstreamProperties.json` definition path to the `fabric_eventstream`
+time: 2025-03-19T00:57:43.4593476-07:00
+custom:
+    Issue: "325"

--- a/.changes/unreleased/fixed-20250512-104313.yaml
+++ b/.changes/unreleased/fixed-20250512-104313.yaml
@@ -1,5 +1,5 @@
 kind: fixed
 body: Added missing `eventstreamProperties.json` definition path to the `fabric_eventstream`
-time: 2025-03-19T00:57:43.4593476-07:00
+time: 2025-05-12T10:43:13.8562644-07:00
 custom:
     Issue: "325"

--- a/docs/data-sources/eventstream.md
+++ b/docs/data-sources/eventstream.md
@@ -76,7 +76,7 @@ output "example_definition_content_object" {
 
 ### Read-Only
 
-- `definition` (Attributes Map) Definition parts. Possible path keys: **Default** format: `eventstream.json` (see [below for nested schema](#nestedatt--definition))
+- `definition` (Attributes Map) Definition parts. Possible path keys: **Default** format: `eventstream.json`, `eventstreamProperties.json` (see [below for nested schema](#nestedatt--definition))
 - `description` (String) The Eventstream description.
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/resources/eventstream.md
+++ b/docs/resources/eventstream.md
@@ -64,7 +64,7 @@ resource "fabric_eventstream" "example_definition_update" {
 
 ### Optional
 
-- `definition` (Attributes Map) Definition parts. Read more about [Eventstream definition part paths](https://learn.microsoft.com/rest/api/fabric/articles/item-management/definitions/eventstream-definition). Accepted path keys: **Default** format: `eventstream.json` (see [below for nested schema](#nestedatt--definition))
+- `definition` (Attributes Map) Definition parts. Read more about [Eventstream definition part paths](https://learn.microsoft.com/rest/api/fabric/articles/item-management/definitions/eventstream-definition). Accepted path keys: **Default** format: `eventstream.json`, `eventstreamProperties.json` (see [below for nested schema](#nestedatt--definition))
 - `definition_update_enabled` (Boolean) Update definition on change of source content. Default: `true`.
 - `description` (String) The Eventstream description.
 - `format` (String) The Eventstream format. Possible values: `Default`

--- a/internal/services/eventstream/base.go
+++ b/internal/services/eventstream/base.go
@@ -30,6 +30,6 @@ var itemDefinitionFormats = []fabricitem.DefinitionFormat{ //nolint:gochecknoglo
 	{
 		Type:  fabricitem.DefinitionFormatDefault,
 		API:   "",
-		Paths: []string{"eventstream.json"},
+		Paths: []string{"eventstream.json", "eventstreamProperties.json"},
 	},
 }

--- a/internal/testhelp/fixtures/eventstream/eventstreamProperties.json
+++ b/internal/testhelp/fixtures/eventstream/eventstreamProperties.json
@@ -1,0 +1,4 @@
+{
+  "retentionTimeInDays": 1,
+  "eventThroughputLevel": "Low"
+}


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several changes to add support for the `eventstreamProperties.json` definition path in the `fabric_eventstream`. The most important changes include updates to documentation, internal service configurations, and test fixtures.

Documentation updates:

* [`docs/data-sources/eventstream.md`](diffhunk://#diff-75c8eb00096d1c6e0215a8e868338c5757a32fcdfb0091534390e47715c6bb03L85-R85): Updated the `definition` attribute description to include the `eventstreamProperties.json` path.
* [`docs/resources/eventstream.md`](diffhunk://#diff-05affd310bebf46df4092c5d429117834a686812778faba8f534d2d8aeaac76bL73-R73): Updated the `definition` attribute description to include the `eventstreamProperties.json` path.

Internal service configuration:

* [`internal/services/eventstream/base.go`](diffhunk://#diff-2fd5666402f2163f42cf9a41042785068deb2581928165dcb034d7b1c9f323a0L30-R30): Added `eventstreamProperties.json` to the list of accepted paths for the `fabric_eventstream` definition format.

Test fixtures:

* [`internal/testhelp/fixtures/eventstream/eventstreamProperties.json`](diffhunk://#diff-6185e8d903d43ce94e11c55ac5eb63a2b7c65aacdecf913813da87837bc9319dR1-R4): Added a new test fixture for `eventstreamProperties.json` with sample data.