### PR TITLE
fix: update items' preview status 

### DIFF
--- a/.changes/unreleased/changed-20250330-073034.yaml
+++ b/.changes/unreleased/changed-20250330-073034.yaml
@@ -1,0 +1,7 @@
+kind: changed
+body: |
+  Mark `fabric_spark_environment_settings` and `fabric_environment` as `preview` due to upcoming API breaking changes:
+  https://learn.microsoft.com/en-us/fabric/data-engineering/environment-public-api
+time: 2025-03-30T07:30:34.869776-07:00
+custom:
+  Issue: "359"

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   The Environment data-source allows you to retrieve details about a Fabric Environment https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment.
   -> This data-source supports Service Principal authentication.
+  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_environment (Data Source)
@@ -12,6 +13,8 @@ description: |-
 The Environment data-source allows you to retrieve details about a Fabric [Environment](https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment).
 
 -> This data-source supports Service Principal authentication.
+
+~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   The Environment data-source allows you to retrieve details about a Fabric Environment https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment.
   -> This data-source supports Service Principal authentication.
+  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_environments (Data Source)
@@ -12,6 +13,8 @@ description: |-
 The Environment data-source allows you to retrieve details about a Fabric [Environment](https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment).
 
 -> This data-source supports Service Principal authentication.
+
+~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/eventstream.md
+++ b/docs/data-sources/eventstream.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The Eventstream data-source allows you to retrieve details about a Fabric Eventstream https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview.
   -> This data-source supports Service Principal authentication.
-  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_eventstream (Data Source)
@@ -13,8 +12,6 @@ description: |-
 The Eventstream data-source allows you to retrieve details about a Fabric [Eventstream](https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview).
 
 -> This data-source supports Service Principal authentication.
-
-~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/eventstreams.md
+++ b/docs/data-sources/eventstreams.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The Eventstreams data-source allows you to retrieve a list of Fabric Eventstreams https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview.
   -> This data-source supports Service Principal authentication.
-  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_eventstreams (Data Source)
@@ -13,8 +12,6 @@ description: |-
 The Eventstreams data-source allows you to retrieve a list of Fabric [Eventstreams](https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview).
 
 -> This data-source supports Service Principal authentication.
-
-~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/graphql_api.md
+++ b/docs/data-sources/graphql_api.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The GraphQL API data-source allows you to retrieve details about a Fabric GraphQL API https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview.
   -> This data-source supports Service Principal authentication.
-  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_graphql_api (Data Source)
@@ -13,8 +12,6 @@ description: |-
 The GraphQL API data-source allows you to retrieve details about a Fabric [GraphQL API](https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview).
 
 -> This data-source supports Service Principal authentication.
-
-~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/graphql_apis.md
+++ b/docs/data-sources/graphql_apis.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The GraphQL APIs data-source allows you to retrieve a list of Fabric GraphQL APIs https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview.
   -> This data-source supports Service Principal authentication.
-  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_graphql_apis (Data Source)
@@ -13,8 +12,6 @@ description: |-
 The GraphQL APIs data-source allows you to retrieve a list of Fabric [GraphQL APIs](https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview).
 
 -> This data-source supports Service Principal authentication.
-
-~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/warehouse.md
+++ b/docs/data-sources/warehouse.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The Warehouse data-source allows you to retrieve details about a Fabric Warehouse https://learn.microsoft.com/fabric/data-warehouse/data-warehousing.
   -> This data-source supports Service Principal authentication.
-  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_warehouse (Data Source)
@@ -13,8 +12,6 @@ description: |-
 The Warehouse data-source allows you to retrieve details about a Fabric [Warehouse](https://learn.microsoft.com/fabric/data-warehouse/data-warehousing).
 
 -> This data-source supports Service Principal authentication.
-
-~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/warehouses.md
+++ b/docs/data-sources/warehouses.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The Warehouse data-source allows you to retrieve details about a Fabric Warehouse https://learn.microsoft.com/fabric/data-warehouse/data-warehousing.
   -> This data-source supports Service Principal authentication.
-  ~> This data-source is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_warehouses (Data Source)
@@ -13,8 +12,6 @@ description: |-
 The Warehouse data-source allows you to retrieve details about a Fabric [Warehouse](https://learn.microsoft.com/fabric/data-warehouse/data-warehousing).
 
 -> This data-source supports Service Principal authentication.
-
-~> This data-source is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   The Environment resource allows you to manage a Fabric Environment https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment.
   -> This resource supports Service Principal authentication.
+  ~> This resource is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_environment (Resource)
@@ -12,6 +13,8 @@ description: |-
 The Environment resource allows you to manage a Fabric [Environment](https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment).
 
 -> This resource supports Service Principal authentication.
+
+~> This resource is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/resources/eventstream.md
+++ b/docs/resources/eventstream.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The Eventstream resource allows you to manage a Fabric Eventstream https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview.
   -> This resource supports Service Principal authentication.
-  ~> This resource is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_eventstream (Resource)
@@ -13,8 +12,6 @@ description: |-
 The Eventstream resource allows you to manage a Fabric [Eventstream](https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview).
 
 -> This resource supports Service Principal authentication.
-
-~> This resource is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/resources/graphql_api.md
+++ b/docs/resources/graphql_api.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The GraphQL API resource allows you to manage a Fabric GraphQL API https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview.
   -> This resource supports Service Principal authentication.
-  ~> This resource is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_graphql_api (Resource)
@@ -13,8 +12,6 @@ description: |-
 The GraphQL API resource allows you to manage a Fabric [GraphQL API](https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview).
 
 -> This resource supports Service Principal authentication.
-
-~> This resource is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/docs/resources/warehouse.md
+++ b/docs/resources/warehouse.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   The Warehouse resource allows you to manage a Fabric Warehouse https://learn.microsoft.com/fabric/data-warehouse/data-warehousing.
   -> This resource supports Service Principal authentication.
-  ~> This resource is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 
 # fabric_warehouse (Resource)
@@ -13,8 +12,6 @@ description: |-
 The Warehouse resource allows you to manage a Fabric [Warehouse](https://learn.microsoft.com/fabric/data-warehouse/data-warehousing).
 
 -> This resource supports Service Principal authentication.
-
-~> This resource is in **preview**. To access it, you must explicitly enable the `preview` mode in the provider level configuration.
 
 ## Example Usage
 

--- a/internal/services/environment/base.go
+++ b/internal/services/environment/base.go
@@ -17,6 +17,6 @@ var ItemTypeInfo = tftypeinfo.TFTypeInfo{ //nolint:gochecknoglobals
 	Names:          "Environments",
 	Types:          "environments",
 	DocsURL:        "https://learn.microsoft.com/fabric/data-engineering/create-and-use-environment",
-	IsPreview:      false,
+	IsPreview:      true,
 	IsSPNSupported: true,
 }

--- a/internal/services/eventstream/base.go
+++ b/internal/services/eventstream/base.go
@@ -22,7 +22,7 @@ var ItemTypeInfo = tftypeinfo.TFTypeInfo{ //nolint:gochecknoglobals
 	Names:          "Eventstreams",
 	Types:          "eventstreams",
 	DocsURL:        "https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview",
-	IsPreview:      true,
+	IsPreview:      false,
 	IsSPNSupported: true,
 }
 

--- a/internal/services/graphqlapi/base.go
+++ b/internal/services/graphqlapi/base.go
@@ -17,6 +17,6 @@ var ItemTypeInfo = tftypeinfo.TFTypeInfo{ //nolint:gochecknoglobals
 	Names:          "GraphQL APIs",
 	Types:          "graphql_apis",
 	DocsURL:        "https://learn.microsoft.com/fabric/data-engineering/api-graphql-overview",
-	IsPreview:      true,
+	IsPreview:      false,
 	IsSPNSupported: true,
 }

--- a/internal/services/warehouse/base.go
+++ b/internal/services/warehouse/base.go
@@ -17,6 +17,6 @@ var ItemTypeInfo = tftypeinfo.TFTypeInfo{ //nolint:gochecknoglobals
 	Names:          "Warehouses",
 	Types:          "warehouses",
 	DocsURL:        "https://learn.microsoft.com/fabric/data-warehouse/data-warehousing",
-	IsPreview:      true,
+	IsPreview:      false,
 	IsSPNSupported: true,
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several changes to the documentation and internal service configurations for various Fabric data sources and resources. The main focus is on updating the preview status of these data sources and resources.

* Set `IsPreview` to `true` for the Environment data-source. (`internal/services/environment/base.go`)
* Set `IsPreview` to `false` for the Eventstream data-source. (`internal/services/eventstream/base.go`)
* Set `IsPreview` to `false` for the GraphQL API data-source. (`internal/services/graphqlapi/base.go`)
* Set `IsPreview` to `false` for the Warehouse data-source. (`internal/services/warehouse/base.go`)
