### PR TITLE
fix(dependabot): ignore microsoft/fabric package in examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,8 @@ updates:
     labels:
       - "deps/terraform"
       - dependencies
+    ignore:
+      - dependency-name: "microsoft/fabric"
     groups:
       all:
         patterns: ["*"]


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Configure dependabot to ignore version update for microsoft/fabric in examples directory
