### PR TITLE
fix(nil pointer): handle fabric error response when RawReponse is nil 

### DIFF
--- a/.changes/unreleased/fixed-20250409-105232.yaml
+++ b/.changes/unreleased/fixed-20250409-105232.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Nil pointer dereference on Fabric Error Responses when RawResponse is nil.
+time: 2025-04-09T10:52:32.927656615Z
+custom:
+    Issue: "362"

--- a/internal/pkg/utils/errors.go
+++ b/internal/pkg/utils/errors.go
@@ -156,7 +156,7 @@ func (h *ErrorHandler) processFabricError(
 	})
 
 	// Handle special case for error identity check or not found errors
-	if (errIs != nil && errors.Is(errResp, errIs)) || (errIs != nil && errResp.RawResponse.StatusCode == http.StatusNotFound) {
+	if errIs != nil && (errors.Is(errResp, errIs) || (errResp.RawResponse != nil && errResp.RawResponse.StatusCode == http.StatusNotFound)) {
 		return errIs.Error(), errIs.Error()
 	}
 


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Fix #362 

- Fix nil pointer dereference in fabric error response when RawResponse is nil. 
- Today this could happen when provisioning a `fabric_lakehouse` or `fabric_mirrored_database` and the underlying sql endpoint provisioning fails.

