### PR TITLE
fix: lint in the codebase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,5 +119,11 @@
     "azcore",
     "customtypes"
   ],
-  "sarif-viewer.connectToGithubCodeScanning": "on"
+  "sarif-viewer.connectToGithubCodeScanning": "on",
+  //copilot
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    {
+      "text": "Use the Conventional Commits specification to create commit message with scope to keep consistent commit history. Do not use file extension. Must be less than 100 characters."
+    }
+  ]
 }

--- a/internal/services/workspacempe/resource_workspace_managed_private_endpoint_test.go
+++ b/internal/services/workspacempe/resource_workspace_managed_private_endpoint_test.go
@@ -39,11 +39,7 @@ func TestAcc_WorkspaceManagedPrivateEndpointResource_CRUD(t *testing.T) {
 	// export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 	// export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 
-	// provider "azurerm" {
-	// 	features {}
-	// 	subscription_id = "%s"
-	// }
-
+	// lintignore:AT004
 	azurermHCL := fmt.Sprintf(`
 		provider "azurerm" {
 			features {}

--- a/internal/testhelp/fakes/fake_typedhandler.go
+++ b/internal/testhelp/fakes/fake_typedhandler.go
@@ -220,7 +220,11 @@ func (h *typedHandler[TEntity]) Get(id string) TEntity {
 		for _, element := range h.elements {
 			item := asFabricItem(element)
 			if strings.HasSuffix(id, *item.ID) {
-				return element.(TEntity)
+				if typedElement, ok := element.(TEntity); ok {
+					return typedElement
+				}
+
+				panic("Element found but type assertion failed") // lintignore:R009
 			}
 		}
 


### PR DESCRIPTION
This pull request includes several changes to configuration files and test files to improve code quality and functionality. The most important changes include updates to `.vscode/settings.json`, the addition of a lint ignore comment in a test file, and a type assertion check in a fake handler.

Updates to configuration files:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L122-R128): Added instructions for commit message generation using the Conventional Commits specification to keep a consistent commit history.

Improvements to test files:

* [`internal/services/workspacempe/resource_workspace_managed_private_endpoint_test.go`](diffhunk://#diff-29841337ee56aec00cece2a4d5a3ceb053627f4ee83e0fae2c5fe4849da7035fL42-R42): Added a lint ignore comment (`lintignore:AT004`) to the test function `TestAcc_WorkspaceManagedPrivateEndpointResource_CRUD`.

Enhancements to type handling:

* [`internal/testhelp/fakes/fake_typedhandler.go`](diffhunk://#diff-112de2c77578ec82d85ecdd32714309ad8524a3fe2ef7186d0ccfc596756333aL223-R227): Added a type assertion check and panic message in the `Get` method to handle cases where the type assertion fails.