### PR TITLE
feat(telemetry): add partner_id and improve user-agent

### DIFF
--- a/.changes/unreleased/added-20250423-104539.yaml
+++ b/.changes/unreleased/added-20250423-104539.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: '`partner_id` and `disable_terraform_partner_id` options to provider configuration to facilitate partner resource usage'
+time: 2025-04-23T10:45:39.9591769-07:00
+custom:
+    Issue: "408"

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,12 +84,14 @@ You can find more information on how to do this in the following guides:
 - `client_id_file_path` (String) The path to a file containing the Client ID which should be used.
 - `client_secret` (String, Sensitive) The Client Secret of the app registration. For use when authenticating as a Service Principal using a Client Secret.
 - `client_secret_file_path` (String) The path to a file containing the Client Secret which should be used. For use when authenticating as a Service Principal using a Client Secret.
+- `disable_terraform_partner_id` (Boolean) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified, which allows Microsoft to better understand the usage of Terraform. The Partner ID does not give HashiCorp any direct access to usage information. This can also be sourced from the `FABRIC_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.
 - `endpoint` (String) The Endpoint of the Microsoft Fabric API.
 - `environment` (String) The cloud environment which should be used. Possible values are 'public', 'usgovernment' and 'china'. Defaults to 'public'
 - `oidc_request_token` (String, Sensitive) The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.
 - `oidc_request_url` (String) The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.
 - `oidc_token` (String, Sensitive) The OIDC token for use when authenticating as a Service Principal using OpenID Connect.
 - `oidc_token_file_path` (String) The path to a file containing an OIDC token for use when authenticating as a Service Principal using OpenID Connect.
+- `partner_id` (String) A GUID/UUID that is [registered](https://learn.microsoft.com/partner-center/marketplace-offers/azure-partner-customer-usage-attribution#register-guids-and-offers) with Microsoft to facilitate partner resource usage attribution.
 - `preview` (Boolean) Enable preview mode to use preview features.
 - `tenant_id` (String) The ID of the Microsoft Entra ID tenant that Fabric API uses to authenticate with.
 - `timeout` (String) Default timeout for all requests. It can be overridden at any Resource/Data-Source

--- a/internal/provider/client/user_agent.go
+++ b/internal/provider/client/user_agent.go
@@ -18,13 +18,13 @@ type UserAgentPolicy struct {
 
 func (c UserAgentPolicy) Do(req *policy.Request) (*http.Response, error) {
 	req.Raw().Header.Set("User-Agent", c.UserAgent)
+
 	return req.Next()
 }
 
 var _ policy.Policy = UserAgentPolicy{}
 
-// WithUserAgent returns a policy.Policy that adds an HTTP extension header of
-// `User-Agent` whose value is passed and has no length limitation
+// WithUserAgent returns a policy.Policy that adds an HTTP extension header of `User-Agent` whose value is passed and has no length limitation.
 func WithUserAgent(userAgent string) policy.Policy {
 	return UserAgentPolicy{UserAgent: userAgent}
 }
@@ -34,13 +34,13 @@ func BuildUserAgent(terraformVersion, sdkVersion, providerVersion, partnerID str
 		terraformVersion = "0.11+compatible"
 	}
 
-	terraformUserAgent := fmt.Sprintf("terraform/%s", terraformVersion)
-	sdkUserAgent := fmt.Sprintf("fabric-sdk-go/%s", sdkVersion)
+	terraformUserAgent := "terraform/" + terraformVersion
+	sdkUserAgent := "fabric-sdk-go/" + sdkVersion
 	providerUserAgent := fmt.Sprintf("terraform-provider-fabric/%s (%s; %s)", providerVersion, runtime.GOOS, runtime.GOARCH)
 	userAgent := strings.TrimSpace(fmt.Sprintf("%s %s %s", terraformUserAgent, sdkUserAgent, providerUserAgent))
 
 	if partnerID == "" && !disableTerraformPartnerID {
-		// Microsoft’s Terraform Partner ID is this specific GUID
+		// Microsoft's Terraform Partner ID is this specific GUID
 		partnerID = "222c6c49-1b0a-5959-a213-6608f9eb8820"
 	}
 

--- a/internal/provider/client/user_agent.go
+++ b/internal/provider/client/user_agent.go
@@ -29,7 +29,7 @@ func WithUserAgent(userAgent string) policy.Policy {
 	return UserAgentPolicy{UserAgent: userAgent}
 }
 
-func BuildUserAgent(terraformVersion, sdkVersion, providerVersion, partnerID string, disableTerraformPartnerID bool) string {
+func BuildUserAgent(terraformVersion, sdkVersion, providerVersion, partnerID string, disableTerraformPartnerID bool) string { //revive:disable-line:flag-parameter
 	if terraformVersion == "" {
 		terraformVersion = "0.11+compatible"
 	}

--- a/internal/provider/client/user_agent.go
+++ b/internal/provider/client/user_agent.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+type UserAgentPolicy struct {
+	UserAgent string
+}
+
+func (c UserAgentPolicy) Do(req *policy.Request) (*http.Response, error) {
+	req.Raw().Header.Set("User-Agent", c.UserAgent)
+	return req.Next()
+}
+
+var _ policy.Policy = UserAgentPolicy{}
+
+// WithUserAgent returns a policy.Policy that adds an HTTP extension header of
+// `User-Agent` whose value is passed and has no length limitation
+func WithUserAgent(userAgent string) policy.Policy {
+	return UserAgentPolicy{UserAgent: userAgent}
+}
+
+func BuildUserAgent(terraformVersion, sdkVersion, providerVersion, partnerID string, disableTerraformPartnerID bool) string {
+	if terraformVersion == "" {
+		terraformVersion = "0.11+compatible"
+	}
+
+	terraformUserAgent := fmt.Sprintf("terraform/%s", terraformVersion)
+	sdkUserAgent := fmt.Sprintf("fabric-sdk-go/%s", sdkVersion)
+	providerUserAgent := fmt.Sprintf("terraform-provider-fabric/%s (%s; %s)", providerVersion, runtime.GOOS, runtime.GOARCH)
+	userAgent := strings.TrimSpace(fmt.Sprintf("%s %s %s", terraformUserAgent, sdkUserAgent, providerUserAgent))
+
+	if partnerID == "" && !disableTerraformPartnerID {
+		// Microsoft’s Terraform Partner ID is this specific GUID
+		partnerID = "222c6c49-1b0a-5959-a213-6608f9eb8820"
+	}
+
+	if partnerID != "" {
+		userAgent = fmt.Sprintf("%s pid-%s", userAgent, partnerID)
+	}
+
+	return userAgent
+}

--- a/internal/provider/config/envvars.go
+++ b/internal/provider/config/envvars.go
@@ -90,3 +90,11 @@ func GetEnvVarsUseCLI() []string {
 func GetEnvVarsPreview() []string {
 	return []string{"FABRIC_PREVIEW"}
 }
+
+func GetEnvVarsPartnerID() []string {
+	return []string{"FABRIC_PARTNER_ID", "ARM_PARTNER_ID"}
+}
+
+func GetEnvVarsDisableTerraformPartnerID() []string {
+	return []string{"FABRIC_DISABLE_TERRAFORM_PARTNER_ID", "ARM_DISABLE_TERRAFORM_PARTNER_ID"}
+}

--- a/internal/provider/config/model.go
+++ b/internal/provider/config/model.go
@@ -15,11 +15,14 @@ import (
 )
 
 type ProviderData struct {
-	FabricClient *fabric.Client
-	Timeout      time.Duration
-	Endpoint     string
-	Version      string
-	Preview      bool
+	FabricClient              *fabric.Client
+	Timeout                   time.Duration
+	Endpoint                  string
+	Version                   string
+	Preview                   bool
+	TerraformVersion          string
+	PartnerID                 string
+	DisableTerraformPartnerID bool
 }
 
 type ProviderConfig struct {
@@ -51,4 +54,6 @@ type ProviderConfigModel struct {
 	UseDevCLI                      types.Bool           `tfsdk:"use_dev_cli"`
 	UseMSI                         types.Bool           `tfsdk:"use_msi"`
 	Preview                        types.Bool           `tfsdk:"preview"`
+	PartnerID                      customtypes.UUID     `tfsdk:"partner_id"`
+	DisableTerraformPartnerID      types.Bool           `tfsdk:"disable_terraform_partner_id"`
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -131,11 +131,6 @@ func createDefaultClient(ctx context.Context, cfg *pconfig.ProviderConfig) (*fab
 
 	fabricClientOpt := &policy.ClientOptions{}
 
-	// ApplicationID is an application-specific identification string to add to the User-Agent.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	fabricClientOpt.Telemetry.ApplicationID = "tffab/" + cfg.Version
-	fabricClientOpt.Telemetry.Disabled = false
-
 	// MaxRetries specifies the maximum number of attempts a failed operation will be retried before producing an error.
 	// Not really an unlimited cap, but sufficiently large enough to be considered as such.
 	fabricClientOpt.Retry.MaxRetries = math.MaxInt32


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request introduces telemetry enhancements and user agent customization for the Microsoft Fabric Terraform provider. The key changes include adding support for custom `partner_id` and an option to disable the default Terraform Partner ID, implementing a user agent policy, and updating the provider's schema and configuration to support these features.

### Telemetry Enhancements:
* Added new attributes to the provider schema: `partner_id` (a GUID/UUID for partner attribution) and `disable_terraform_partner_id` (to disable the default Terraform Partner ID). These attributes can also be sourced from environment variables. (`internal/provider/provider.go`, [internal/provider/provider.goR332-R342](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R332-R342))
* Updated `ProviderData` and `ProviderConfigModel` to include `PartnerID` and `DisableTerraformPartnerID` fields. (`internal/provider/config/model.go`, [[1]](diffhunk://#diff-debc83e64751f3f9b2071cdc1308a08dbb9c538e0f8b26fe989c581c8d09521fR23-R25) [[2]](diffhunk://#diff-debc83e64751f3f9b2071cdc1308a08dbb9c538e0f8b26fe989c581c8d09521fR57-R58)
* Implemented environment variable support for `FABRIC_PARTNER_ID`, `ARM_PARTNER_ID`, `FABRIC_DISABLE_TERRAFORM_PARTNER_ID`, and `ARM_DISABLE_TERRAFORM_PARTNER_ID`. (`internal/provider/config/envvars.go`, [internal/provider/config/envvars.goR93-R100](diffhunk://#diff-462c937cad8ff5caf6a321d37f931711afca9cca644d64df72fcd6106dbb5c15R93-R100))

### User Agent Customization:
* Introduced a `UserAgentPolicy` and helper functions (`WithUserAgent` and `BuildUserAgent`) to customize the `User-Agent` HTTP header with Terraform, SDK, and provider version details, along with partner ID information. (`internal/provider/client/user_agent.go`, [internal/provider/client/user_agent.goR1-R52](diffhunk://#diff-b134017d014046bbab530f49c1224228179b2b27aa266a92e779e79894e3f97eR1-R52))
* Integrated the custom user agent into the Fabric client by appending the `UserAgentPolicy` to the per-call policies. (`internal/provider/provider.go`, [internal/provider/provider.goR174-R177](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R174-R177))

### Configuration Updates:
* Enhanced the provider's configuration handling to map and validate the new telemetry-related fields (`partner_id` and `disable_terraform_partner_id`) and set their values from the schema or environment variables. (`internal/provider/provider.go`, [[1]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R688-R698) [[2]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R791-R792)
* Captured the Terraform version in the provider's configuration for use in the user agent string. (`internal/provider/provider.go`, [internal/provider/provider.goR379-R380](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R379-R380))