### PR TITLE
fix(errors): handle nil in auth error

### DIFF
--- a/.changes/unreleased/fixed-20250515-194639.yaml
+++ b/.changes/unreleased/fixed-20250515-194639.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Handle runtime error / nil pointer in the AuthenticationFailedError error
+time: 2025-05-15T19:46:39.4887143-07:00
+custom:
+  Issue: "440"

--- a/internal/pkg/utils/errors.go
+++ b/internal/pkg/utils/errors.go
@@ -211,6 +211,11 @@ func (h *ErrorHandler) processFabricError(
 func (h *ErrorHandler) processAuthFailedError(ctx context.Context, errAuthFailed *azidentity.AuthenticationFailedError) (string, string) { //revive:disable-line:confusing-results
 	var errAuthResp authErrorResponse
 
+	// Check if RawResponse is nil to avoid panic
+	if errAuthFailed.RawResponse == nil {
+		return "AuthenticationFailedError", errAuthFailed.Error()
+	}
+
 	err := errAuthResp.getErrFromResp(errAuthFailed.RawResponse)
 	if err != nil {
 		return "Failed to parse authentication error response", err.Error()
@@ -272,7 +277,7 @@ type authErrorResponse struct {
 
 // getErrFromResp parses an HTTP response body into an authErrorResponse.
 func (e *authErrorResponse) getErrFromResp(resp *http.Response) error {
-	if resp.Body == nil {
+	if resp == nil || resp.Body == nil {
 		return nil
 	}
 


### PR DESCRIPTION
# 📥 Pull Request

close #440

## ❓ What are you trying to address

The panic was occurring because:

1. An `azidentity.AuthenticationFailedError` was being passed to `processAuthFailedError`
2. The `RawResponse` field in this error was nil
3. The code was trying to access `resp.Body` in `getErrFromResp` without checking if `resp` itself was nil
4. This resulted in a nil pointer dereference (trying to access the `Body` field of a nil pointer)

The fix adds appropriate nil checks to prevent this panic situation and provides default error messages when these fields are not available.

## ✨ Description of new changes

1. Modified `processAuthFailedError` to check if `errAuthFailed.RawResponse` is nil before passing it to `getErrFromResp`.
2. Modified `getErrFromResp` to check if the `resp` parameter itself is nil, not just if `resp.Body` is nil.

These changes should fix the nil pointer dereference issue occurring during authentication error handling. The code now handles cases where the authentication failed error has a nil `RawResponse`.
