### PR TITLE
fix(tests): update workspace reference for resource

### DIFF
--- a/docs/data-sources/activators.md
+++ b/docs/data-sources/activators.md
@@ -37,7 +37,7 @@ data "fabric_activators" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Activators. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Activators. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/copy_jobs.md
+++ b/docs/data-sources/copy_jobs.md
@@ -34,7 +34,7 @@ data "fabric_copy_jobs" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Copy Jobs. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Copy Jobs. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/dashboards.md
+++ b/docs/data-sources/dashboards.md
@@ -37,7 +37,7 @@ data "fabric_dashboards" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Dashboards. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Dashboards. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/data_pipelines.md
+++ b/docs/data-sources/data_pipelines.md
@@ -34,7 +34,7 @@ data "fabric_data_pipelines" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Data Pipelines. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Data Pipelines. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/datamarts.md
+++ b/docs/data-sources/datamarts.md
@@ -37,7 +37,7 @@ data "fabric_datamarts" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Datamarts. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Datamarts. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -31,7 +31,7 @@ data "fabric_domains" "example" {}
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Domains. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Domains. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -37,7 +37,7 @@ data "fabric_environments" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Environments. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Environments. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/eventhouses.md
+++ b/docs/data-sources/eventhouses.md
@@ -34,7 +34,7 @@ data "fabric_eventhouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Eventhouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Eventhouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/eventstreams.md
+++ b/docs/data-sources/eventstreams.md
@@ -34,7 +34,7 @@ data "fabric_eventstreams" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Eventstreams. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Eventstreams. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/graphql_apis.md
+++ b/docs/data-sources/graphql_apis.md
@@ -34,7 +34,7 @@ data "fabric_graphql_apis" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of GraphQL APIs. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of GraphQL APIs. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/kql_dashboards.md
+++ b/docs/data-sources/kql_dashboards.md
@@ -34,7 +34,7 @@ data "fabric_kql_dashboards" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of KQL Dashboards. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of KQL Dashboards. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/kql_databases.md
+++ b/docs/data-sources/kql_databases.md
@@ -34,7 +34,7 @@ data "fabric_kql_databases" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of KQL Databases. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of KQL Databases. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/kql_querysets.md
+++ b/docs/data-sources/kql_querysets.md
@@ -34,7 +34,7 @@ data "fabric_kql_querysets" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of KQL Querysets. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of KQL Querysets. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/lakehouses.md
+++ b/docs/data-sources/lakehouses.md
@@ -34,7 +34,7 @@ data "fabric_lakehouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Lakehouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Lakehouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/mirrored_databases.md
+++ b/docs/data-sources/mirrored_databases.md
@@ -34,7 +34,7 @@ data "fabric_mirrored_databases" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Mirrored Databases. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Mirrored Databases. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/mirrored_warehouses.md
+++ b/docs/data-sources/mirrored_warehouses.md
@@ -37,7 +37,7 @@ data "fabric_mirrored_warehouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Mirrored Warehouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Mirrored Warehouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/ml_experiments.md
+++ b/docs/data-sources/ml_experiments.md
@@ -37,7 +37,7 @@ data "fabric_ml_experiments" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of ML Experiments. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of ML Experiments. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/ml_models.md
+++ b/docs/data-sources/ml_models.md
@@ -37,7 +37,7 @@ data "fabric_ml_models" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of ML Models. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of ML Models. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/mounted_data_factories.md
+++ b/docs/data-sources/mounted_data_factories.md
@@ -34,7 +34,7 @@ data "fabric_mounted_data_factories" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Mounted Data Factories. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Mounted Data Factories. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/notebooks.md
+++ b/docs/data-sources/notebooks.md
@@ -34,7 +34,7 @@ data "fabric_notebooks" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Notebooks. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Notebooks. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/paginated_reports.md
+++ b/docs/data-sources/paginated_reports.md
@@ -37,7 +37,7 @@ data "fabric_paginated_reports" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Paginated Reports. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Paginated Reports. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/reports.md
+++ b/docs/data-sources/reports.md
@@ -34,7 +34,7 @@ data "fabric_reports" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Reports. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Reports. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/semantic_models.md
+++ b/docs/data-sources/semantic_models.md
@@ -34,7 +34,7 @@ data "fabric_semantic_models" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Semantic Models. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Semantic Models. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/spark_job_definitions.md
+++ b/docs/data-sources/spark_job_definitions.md
@@ -34,7 +34,7 @@ data "fabric_spark_job_definitions" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Spark Job Definitions. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Spark Job Definitions. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/sql_databases.md
+++ b/docs/data-sources/sql_databases.md
@@ -37,7 +37,7 @@ data "fabric_sql_databases" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of SQL Databases. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of SQL Databases. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/sql_endpoints.md
+++ b/docs/data-sources/sql_endpoints.md
@@ -37,7 +37,7 @@ data "fabric_sql_endpoints" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of SQL Endpoints. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of SQL Endpoints. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/warehouses.md
+++ b/docs/data-sources/warehouses.md
@@ -34,7 +34,7 @@ data "fabric_warehouses" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The list of Warehouses. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Warehouses. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/data-sources/workspace_managed_private_endpoints.md
+++ b/docs/data-sources/workspace_managed_private_endpoints.md
@@ -37,7 +37,7 @@ data "fabric_workspace_managed_private_endpoints" "example" {
 
 ### Read-Only
 
-- `values` (Attributes Set) The collection of Workspace Managed Private Endpoints. (see [below for nested schema](#nestedatt--values))
+- `values` (Attributes Set) The set of Workspace Managed Private Endpoints. (see [below for nested schema](#nestedatt--values))
 
 <a id="nestedatt--timeouts"></a>
 

--- a/docs/resources/domain_role_assignments.md
+++ b/docs/resources/domain_role_assignments.md
@@ -41,7 +41,7 @@ resource "fabric_domain_role_assignments" "example" {
 ### Required
 
 - `domain_id` (String) <i style="color:red;font-weight: bold">(ForceNew)</i> The Domain ID.
-- `principals` (Attributes Set) <i style="color:red;font-weight: bold">(ForceNew)</i> The list of Principals. (see [below for nested schema](#nestedatt--principals))
+- `principals` (Attributes Set) <i style="color:red;font-weight: bold">(ForceNew)</i> The set of Principals. (see [below for nested schema](#nestedatt--principals))
 - `role` (String) <i style="color:red;font-weight: bold">(ForceNew)</i> The Role of the principals. Value must be one of : `Admins`, `Contributors`.
 
 ### Optional

--- a/internal/pkg/fabricitem/data_items.go
+++ b/internal/pkg/fabricitem/data_items.go
@@ -54,7 +54,7 @@ func (d *DataSourceFabricItems) Schema(ctx context.Context, _ datasource.SchemaR
 			},
 			"values": schema.SetNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: fmt.Sprintf("The list of %s.", d.TypeInfo.Names),
+				MarkdownDescription: fmt.Sprintf("The set of %s.", d.TypeInfo.Names),
 				CustomType:          supertypes.NewSetNestedObjectTypeOf[fabricItemModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/pkg/fabricitem/data_items_properties.go
+++ b/internal/pkg/fabricitem/data_items_properties.go
@@ -75,7 +75,7 @@ func (d *DataSourceFabricItemsProperties[Ttfprop, Titemprop]) Schema(ctx context
 			},
 			"values": schema.SetNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: fmt.Sprintf("The list of %s.", d.TypeInfo.Names),
+				MarkdownDescription: fmt.Sprintf("The set of %s.", d.TypeInfo.Names),
 				CustomType:          supertypes.NewSetNestedObjectTypeOf[FabricItemPropertiesModel[Ttfprop, Titemprop]](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: attributes,

--- a/internal/services/copyjob/resource_copy_job_test.go
+++ b/internal/services/copyjob/resource_copy_job_test.go
@@ -26,7 +26,7 @@ var testHelperLocals = at.CompileLocalsConfig(map[string]any{
 })
 
 var (
-	workspace   = testhelp.WellKnown()["WorkspaceDS"].(map[string]any)
+	workspace   = testhelp.WellKnown()["WorkspaceRS"].(map[string]any)
 	workspaceID = workspace["id"].(string)
 	lakehouse   = testhelp.WellKnown()["Lakehouse"].(map[string]any)
 	lakehouseID = lakehouse["id"].(string)

--- a/internal/services/domain/data_domains.go
+++ b/internal/services/domain/data_domains.go
@@ -47,7 +47,7 @@ func (d *dataSourceDomains) Schema(ctx context.Context, _ datasource.SchemaReque
 		MarkdownDescription: s.GetMarkdownDescription(),
 		Attributes: map[string]schema.Attribute{
 			"values": schema.SetNestedAttribute{
-				MarkdownDescription: "The list of " + d.TypeInfo.Names + ".",
+				MarkdownDescription: "The set of " + d.TypeInfo.Names + ".",
 				Computed:            true,
 				CustomType:          supertypes.NewSetNestedObjectTypeOf[baseDomainModel](ctx),
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/services/domainra/schema.go
+++ b/internal/services/domainra/schema.go
@@ -95,7 +95,7 @@ func itemSchema(isList bool) superschema.Schema { //revive:disable-line:flag-par
 			},
 			"principals": superschema.SuperSetNestedAttributeOf[principalModel]{
 				Common: &schemaR.SetNestedAttribute{
-					MarkdownDescription: "The list of Principals.",
+					MarkdownDescription: "The set of Principals.",
 				},
 				Resource: &schemaR.SetNestedAttribute{
 					Required: true,

--- a/internal/services/mirroreddatabase/resource_mirrored_database_test.go
+++ b/internal/services/mirroreddatabase/resource_mirrored_database_test.go
@@ -297,7 +297,7 @@ func TestUnit_MirroredDatabaseResource_CRUD(t *testing.T) {
 }
 
 func TestAcc_MirroredDatabaseResource_CRUD(t *testing.T) {
-	workspace := testhelp.WellKnown()["WorkspaceDS"].(map[string]any)
+	workspace := testhelp.WellKnown()["WorkspaceRS"].(map[string]any)
 	workspaceID := workspace["id"].(string)
 
 	entityCreateDisplayName := testhelp.RandomName()

--- a/internal/services/workspacempe/data_workspace_managed_private_endpoints.go
+++ b/internal/services/workspacempe/data_workspace_managed_private_endpoints.go
@@ -56,7 +56,7 @@ func (d *dataSourceWorkspaceManagedPrivateEndpoints) Schema(ctx context.Context,
 				CustomType:          customtypes.UUIDType{},
 			},
 			"values": schema.SetNestedAttribute{
-				MarkdownDescription: "The collection of " + d.TypeInfo.Names + ".",
+				MarkdownDescription: "The set of " + d.TypeInfo.Names + ".",
 				Computed:            true,
 				CustomType:          supertypes.NewSetNestedObjectTypeOf[baseWorkspaceManagedPrivateEndpointModel](ctx),
 				NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request updates reference for the right workspace in the acc tests and the documentation for various Fabric data sources by standardizing the terminology used to describe the `values` attribute. Specifically, the term "list" has been replaced with "set" to better reflect the attribute type. The changes affect multiple data sources, ensuring consistency across the documentation.