### PR TITLE
feat(fix): skip acc test for ephemeral eventstream_source_connection due to throttling issues

### DIFF
--- a/internal/services/eventstreamsourceconnection/ephemeral_evenstream_source_connection_test.go
+++ b/internal/services/eventstreamsourceconnection/ephemeral_evenstream_source_connection_test.go
@@ -211,6 +211,10 @@ func TestUnit_EventstreamSourceConnectionEphemeralResource(t *testing.T) {
 }
 
 func TestAcc_EventstreamSourceConnectionEphemeralResource(t *testing.T) {
+	if testhelp.ShouldSkipTest(t) {
+		t.Skip("Thorttling issues which blocks all PR tests in the pipeline")
+	}
+
 	workspace := testhelp.WellKnown()["WorkspaceDS"].(map[string]any)
 	workspaceID := workspace["id"].(string)
 

--- a/internal/services/eventstreamsourceconnection/ephemeral_evenstream_source_connection_test.go
+++ b/internal/services/eventstreamsourceconnection/ephemeral_evenstream_source_connection_test.go
@@ -212,7 +212,7 @@ func TestUnit_EventstreamSourceConnectionEphemeralResource(t *testing.T) {
 
 func TestAcc_EventstreamSourceConnectionEphemeralResource(t *testing.T) {
 	if testhelp.ShouldSkipTest(t) {
-		t.Skip("Thorttling issues which blocks all PR tests in the pipeline")
+		t.Skip("Throttling issues which blocks all PR tests in the pipeline")
 	}
 
 	workspace := testhelp.WellKnown()["WorkspaceDS"].(map[string]any)


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Due to API throttling limitations to eventstream_source_connection and returned http status code is 400 instead of 429, the polling mechanism on the GO SDK is not applied, and the tests are throttled, and so all test checks in the PRs will fail on throttling and would require manual rerun.


## ✨ Description of new changes

Skipping the ephemeral eventstream_source_connection acc test until issues is fixed on the API side.

## ☑️ PR Checklist

- [ ] Link to the issue you are addressing is included above
- [ ] Ensure the PR description clearly describes the feature you're adding and any known limitations

## ☑️ Resources / Data Sources Checklist

PRs for new/enhanced resources or data sources are expected to meet the following criteria:

- [ ] Production quality implementation of the resource or data-source in [./internal/services](./internal/services)
- [ ] Unit Tests and Acceptance Tests for your contribution in [./internal/services/<service_name>](./internal/services)
  - [ ] Tests should pass and provide >80% coverage of your contribution
- [ ] Examples for your contribution in [./examples](./examples) (see [Terraform Documentation on examples](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-documentation-generation#add-configuration-examples))
- [ ] [Schema descriptions](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-documentation-generation#add-schema-descriptions) for your resource or data-source in [./internal/services](./internal/services)
- [ ] Docs templates in [./templates](./templates)
- [ ] Updated auto-generated documentation in [./docs](./docs). (DO NOT manually edit [./docs](./docs) - your updates will be overwritten)
