### PR TITLE
fix(docs): remove redundant md description in ephemeral resource 

### DIFF
--- a/docs/ephemeral-resources/eventstream_source_connection.md
+++ b/docs/ephemeral-resources/eventstream_source_connection.md
@@ -4,7 +4,6 @@ page_title: "fabric_eventstream_source_connection Ephemeral Resource - terraform
 subcategory: ""
 description: |-
   The Eventstream Source Connection ephemeral resource allows you to manage a temporary Fabric Eventstream Source Connection https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview.
-  -> Ephemeral Resources are supported in HashiCorp Terraform version 1.11 and later.
   -> This resource supports Service Principal authentication.
   ~> This ephemeral resource is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
@@ -12,8 +11,6 @@ description: |-
 # fabric_eventstream_source_connection (Ephemeral Resource)
 
 The Eventstream Source Connection ephemeral resource allows you to manage a temporary Fabric [Eventstream Source Connection](https://learn.microsoft.com/fabric/real-time-intelligence/event-streams/overview).
-
--> Ephemeral Resources are supported in HashiCorp Terraform version 1.11 and later.
 
 -> This resource supports Service Principal authentication.
 

--- a/internal/pkg/fabricitem/helpers.go
+++ b/internal/pkg/fabricitem/helpers.go
@@ -97,8 +97,6 @@ func NewEphemeralResourceMarkdownDescription(typeInfo tftypeinfo.TFTypeInfo, plu
 		md += fmt.Sprintf(" %s.", typeInfo.Name)
 	}
 
-	md += "\n\n-> Ephemeral Resources are supported in HashiCorp Terraform version 1.11 and later."
-
 	if typeInfo.IsSPNSupported {
 		md += SPNSupportedResource
 	} else {


### PR DESCRIPTION
The documentation automatically has the above note added
![image](https://github.com/user-attachments/assets/2dd8ac0c-bb00-45d5-8c15-34e924dd429f)


Therefore, this PR remove the redundant (and inaccurate) note that we added