### PR TITLE
fix(tests): increase timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   FABRIC_TESTACC_SKIP_NO_SPN: true
   FABRIC_TESTACC_WELLKNOWN: ${{ vars.FABRIC_TESTACC_WELLKNOWN }}
-  FABRIC_TIMEOUT: 20m
+  FABRIC_TIMEOUT: 30m
 
 permissions:
   id-token: write
@@ -311,7 +311,7 @@ jobs:
     environment:
       name: development
     runs-on: ubuntu-24.04
-    timeout-minutes: 40
+    timeout-minutes: 45
     permissions:
       contents: read
       actions: read
@@ -393,7 +393,7 @@ jobs:
       - name: 🧪 Run tests
         if: matrix.cli == 'terraform'
         run: task test
-        timeout-minutes: 40
+        timeout-minutes: 45
         env:
           # TF_LOG: DEBUG
           FABRIC_USE_OIDC: true
@@ -407,7 +407,7 @@ jobs:
       - name: 🧪 Run tests
         if: matrix.cli == 'tofu'
         run: task test
-        timeout-minutes: 40
+        timeout-minutes: 45
         env:
           FABRIC_USE_OIDC: true
           FABRIC_TENANT_ID: ${{ secrets.TESTACC_TENANT_ID }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,7 +69,7 @@
     "FABRIC_SDK_GO_LOGGING_ALLOWED_QUERY_PARAMS": "format;type;continuationToken"
   },
   "go.diagnostic.vulncheck": "Imports",
-  "go.testTimeout": "5m",
+  "go.testTimeout": "10m",
   "go.lintTool": "golangci-lint",
   "go.lintFlags": [
     "--fast-only"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -273,7 +273,7 @@ tasks:
   testunit:
     desc: Run unit tests
     cmds:
-      - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" -- {{.TEST_PATH}} -run "^TestUnit_{{.TEST_NAME}}" -p {{numCPU}} -timeout 5m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
+      - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" -- {{.TEST_PATH}} -run "^TestUnit_{{.TEST_NAME}}" -p {{numCPU}} -timeout 10m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
       - task: test:getcover
     vars:
       TEST_NAME: "{{if gt (len (splitArgs .CLI_ARGS)) 0}}{{index (splitArgs .CLI_ARGS) 0}}{{end}}"
@@ -288,7 +288,7 @@ tasks:
     desc: Run acceptance tests
     cmds:
       - go clean -testcache
-      - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" -- {{.TEST_PATH}} -run "^TestAcc_{{.TEST_NAME}}" -p {{numCPU}} -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
+      - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" -- {{.TEST_PATH}} -run "^TestAcc_{{.TEST_NAME}}" -p {{numCPU}} -timeout 45m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
       - task: test:getcover
     vars:
       TEST_NAME: "{{if gt (len (splitArgs .CLI_ARGS)) 0}}{{index (splitArgs .CLI_ARGS) 0}}{{end}}"
@@ -304,7 +304,7 @@ tasks:
     cmds:
       - go clean -testcache
       - go test -failfast -run ^TestDevEnv_WellKnown$ ./internal/testhelp
-      - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" -- {{.TEST_PATH}} -run "^Test(Acc|Unit)_{{.TEST_NAME}}" -p {{numCPU}} -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic -coverpkg={{.GO_PKGS}}'
+      - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" -- {{.TEST_PATH}} -run "^Test(Acc|Unit)_{{.TEST_NAME}}" -p {{numCPU}} -timeout 45m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic -coverpkg={{.GO_PKGS}}'
       - task: test:getcover
     vars:
       TEST_NAME: "{{if gt (len (splitArgs .CLI_ARGS)) 0}}{{index (splitArgs .CLI_ARGS) 0}}{{end}}"


### PR DESCRIPTION
This pull request increases the default timeouts for various test commands and workflows to help prevent premature test failures due to longer-running tests. The changes affect both CI workflow configurations and local development/test settings.

**CI workflow timeout increases:**

* In `.github/workflows/test.yml`, the global environment variable `FABRIC_TIMEOUT` was increased from 20m to 30m, and individual job/test step timeouts were raised from 40 to 45 minutes for both `terraform` and `tofu` CLI matrix jobs. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L30-R30) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L314-R314) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L396-R396) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L410-R410)

**Local development and test configuration:**

* In `.vscode/settings.json`, the Go test timeout setting was increased from 5m to 10m to allow for longer local test runs.

**Taskfile test timeout increases:**

* In `Taskfile.yml`, the unit test timeout was raised from 5m to 10m, and acceptance and combined test timeouts were increased from 30m to 45m. This affects the `testunit`, `testacc`, and `testall` tasks. [[1]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eL276-R276) [[2]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eL291-R291) [[3]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eL307-R307)