### PR TITLE
fix(script): fix WorkspaceRS cleanup script

### DIFF
--- a/tools/scripts/Remove-WorkspaceRSItems.ps1
+++ b/tools/scripts/Remove-WorkspaceRSItems.ps1
@@ -254,7 +254,6 @@ function Remove-WorkspaceRSItems {
     $_.type -ne 'KQLDatabase' -and
     $_.type -ne 'SQLEndpoint' -and
     -not ($_.type -eq 'Lakehouse' -and $_.displayName -eq 'lh')
-
   }
 
   Write-Log -Message "Preserving any lakehouse named 'lh'" -Level 'INFO' -Stop $false


### PR DESCRIPTION
This pull request updates the `Remove-WorkspaceRSItems.ps1` script to improve the logic for preserving items in the workspace and enhance error handling during deletion. The main changes include broadening the criteria for preserved items and making the deletion process more robust against missing items.

**Preservation logic improvements:**

* The script now preserves any lakehouse item named `'lh'`. [[1]](diffhunk://#diff-57349a2585a171f00723c1a24cc6ec03f74cbe5d9b5026a9e979e5d1d5e79675L5-R9) [[2]](diffhunk://#diff-57349a2585a171f00723c1a24cc6ec03f74cbe5d9b5026a9e979e5d1d5e79675L255-R260)

**Deletion process enhancements:**

* The deletion logic now treats HTTP 404 responses as successful deletions, logging that the item was already deleted or not found, instead of treating them as errors. [[1]](diffhunk://#diff-57349a2585a171f00723c1a24cc6ec03f74cbe5d9b5026a9e979e5d1d5e79675L313-R317) [[2]](diffhunk://#diff-57349a2585a171f00723c1a24cc6ec03f74cbe5d9b5026a9e979e5d1d5e79675R326-R336)