### PR TITLE
docs: clarify fabric_domain requires delegated admin context

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -3,9 +3,9 @@
 page_title: "fabric_domain Resource - terraform-provider-fabric"
 subcategory: ""
 description: |-
-  The Domain resource allows you to manage a Fabric Domain https://learn.microsoft.com/fabric/governance/domains.
+   The Domain resource allows you to manage a Fabric Domain https://learn.microsoft.com/fabric/governance/domains.
   -> This resource supports Service Principal authentication.
-  -> Fabric Domains require a delegated Fabric Admin user context. Domain operations cannot be executed using a Service Principal.
+  -> Fabric Domain operations require admin API access and may fail if the Service Principal has the Tenant.ReadWrite.All permission assigned.
   ~> This resource is in preview. To access it, you must explicitly enable the preview mode in the provider level configuration.
 ---
 


### PR DESCRIPTION
Fixes #742
Clarifies that fabric_domain requires a delegated Fabric Admin user context even though Service Principal authentication is supported by the provider.