### PR TITLE
docs: clarify gateway resource type support

### DIFF
--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -13,6 +13,8 @@ The Gateway resource allows you to manage a Fabric [Gateway](https://learn.micro
 
 -> This resource supports Service Principal authentication.
 
+~> This resource provisions only `VirtualNetwork` gateways. `OnPremises` and `OnPremisesPersonal` gateways can be discovered with the `fabric_gateway` and `fabric_gateways` data sources, but they cannot be created or managed with this resource.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
## Summary
- clarify that the fabric_gateway resource provisions only VirtualNetwork gateways
- point users to gateway data sources for OnPremises and OnPremisesPersonal discovery

Fixes #977.

## Testing
- git diff --check