### PR TITLE
fix(tests): Enable GatewayRoleAssignmentResource CRUD test

### DIFF
--- a/internal/services/gatewayra/resource_gateway_role_assignment_test.go
+++ b/internal/services/gatewayra/resource_gateway_role_assignment_test.go
@@ -157,9 +157,6 @@ func TestUnit_GatewayRoleAssignmentResource_ImportState(t *testing.T) {
 }
 
 func TestAcc_GatewayRoleAssignmentResource_CRUD(t *testing.T) {
-	if testhelp.ShouldSkipTest(t) {
-		t.Skip("No SPN support")
-	}
 
 	gatewayType := string(fabcore.GatewayTypeVirtualNetwork)
 	gatewayCreateDisplayName := testhelp.RandomName()


### PR DESCRIPTION
Removed the skip condition for the Gateway Role Assignment Resource test.

