### PR TITLE
feat(tools): add previewcheck and gapcheck scripts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,6 +105,11 @@ tasks:
     cmds:
       - go run ./tools/previewcheck {{.CLI_ARGS}}
 
+  check:gaps:
+    desc: Detect SDK control-plane entities with no corresponding Terraform resource
+    cmds:
+      - go run ./tools/gapcheck {{.CLI_ARGS}}
+
   lint:tf:
     desc: Run Terraform linters
     cmds:
@@ -294,6 +299,15 @@ tasks:
       TF_ACC: 0
       GOCOVERDIR: ".coverdata"
       # CGO_ENABLED: 1
+
+  test:gaptools:
+    desc: Run unit tests for the gapcheck/previewcheck developer tools
+    cmds:
+      - go test -count=1 -timeout 5m ./tools/gapcheck/... ./tools/previewcheck/... ./tools/internal/toolutil/...
+    env:
+      # Fail loudly if the fabric-sdk-go module cannot be resolved instead of
+      # silently skipping the SDK-backed guard tests.
+      GAPCHECK_REQUIRE_SDK: "1"
 
   testacc:
     desc: Run acceptance tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,6 +100,11 @@ tasks:
     cmds:
       - tfproviderlintx -fix ./...
 
+  check:preview:
+    desc: Verify each resource/data source IsPreview flag matches the fabric-sdk-go API preview status
+    cmds:
+      - go run ./tools/previewcheck {{.CLI_ARGS}}
+
   lint:tf:
     desc: Run Terraform linters
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,6 +105,11 @@ tasks:
     cmds:
       - go run ./tools/previewcheck {{.CLI_ARGS}}
 
+  check:spn:
+    desc: Verify each resource/data source IsSPNSupported flag matches the fabric-sdk-go API service principal support
+    cmds:
+      - go run ./tools/spncheck {{.CLI_ARGS}}
+
   check:gaps:
     desc: Detect SDK control-plane entities with no corresponding Terraform resource
     cmds:
@@ -301,9 +306,9 @@ tasks:
       # CGO_ENABLED: 1
 
   test:gaptools:
-    desc: Run unit tests for the gapcheck/previewcheck developer tools
+    desc: Run unit tests for the gapcheck/previewcheck/spncheck developer tools
     cmds:
-      - go test -count=1 -timeout 5m ./tools/gapcheck/... ./tools/previewcheck/... ./tools/internal/toolutil/...
+      - go test -count=1 -timeout 5m ./tools/gapcheck/... ./tools/previewcheck/... ./tools/spncheck/... ./tools/internal/toolutil/...
     env:
       # Fail loudly if the fabric-sdk-go module cannot be resolved instead of
       # silently skipping the SDK-backed guard tests.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/orange-cloudavenue/terraform-plugin-framework-supertypes v1.2.0
 	github.com/orange-cloudavenue/terraform-plugin-framework-validators v1.16.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/tools v0.44.0
 	software.sslmate.com/src/go-pkcs12 v0.7.2
 )
 
@@ -82,7 +83,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/orange-cloudavenue/terraform-plugin-framework-supertypes v1.2.0
 	github.com/orange-cloudavenue/terraform-plugin-framework-validators v1.16.0
 	github.com/stretchr/testify v1.11.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/tools v0.44.0
 	software.sslmate.com/src/go-pkcs12 v0.7.2
 )
@@ -76,7 +77,6 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.18.1 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/tools/gapcheck/README.md
+++ b/tools/gapcheck/README.md
@@ -63,8 +63,5 @@ exclusions:
 You do **not** need to exclude methods that are already used by an existing
 resource — those are detected automatically from the provider source.
 
-## CI
-
-The `test-gaptools` job in `.github/workflows/test.yml` runs the tool's unit
-tests (via `task test:gaptools`) whenever `tools/**` changes. Run the audit
-locally with the commands above before adding new SDK-backed resources.
+Run the audit locally with the commands above before adding new SDK-backed
+resources. The tool's unit tests run via `task test:gaptools`.

--- a/tools/gapcheck/README.md
+++ b/tools/gapcheck/README.md
@@ -1,0 +1,70 @@
+# gapcheck
+
+`gapcheck` finds control-plane Fabric entities exposed by
+[`fabric-sdk-go`](https://github.com/microsoft/fabric-sdk-go) that have **no
+corresponding Terraform resource** in this provider — so we can spot SDK
+capabilities the provider does not yet cover.
+
+## How it works
+
+1. Scans the SDK's `*_client.go` files and collects every exported client method
+   (e.g. `core/WorkspacesClient.CreateWorkspace`).
+2. Scans this provider's service packages to learn which SDK methods are already
+   called (i.e. already covered by a resource).
+3. Reports every SDK method that is **not** covered, **not** an action-style
+   verb (e.g. `Cancel`, `Assign`), and **not** listed in `exclusions.yaml`.
+
+The report is intentionally **exhaustive**: it lists read-only/list-only/
+update-only methods too, not just missing Create/Delete lifecycles. Everything
+that isn't genuinely a resource gap is pruned explicitly via `exclusions.yaml`,
+which keeps the list honest and reviewable.
+
+## Run it
+
+```sh
+go run ./tools/gapcheck            # human-readable report
+go run ./tools/gapcheck -json      # machine-readable JSON
+go run ./tools/gapcheck -dir DIR   # scan a different services directory
+go run ./tools/gapcheck -exclusions PATH   # use a specific exclusions file
+```
+
+Exit codes: `0` = no gaps, `1` = gaps or stale exclusions found, `2` = error.
+
+## Reading the output
+
+- **GAPS** — SDK methods with no TF coverage and no exclusion. Each is a
+  candidate to either implement or exclude.
+- **EXCLUDED** — count of methods suppressed by `exclusions.yaml`.
+- **STALE EXCLUSIONS** — methods that are now implemented but still listed in
+  `exclusions.yaml`; remove them. Stale entries also fail the run (exit `1`).
+
+## Acting on a failure
+
+For each reported gap, do **one** of:
+
+- **Implement it** as a Terraform resource/data source (the tool will then
+  auto-detect the SDK calls and stop reporting it), **or**
+- **Exclude it** in [`exclusions.yaml`](./exclusions.yaml) with a reason.
+
+Exclusion format — `package/client/method → reason`. Omit `method` (or set it to
+`"*"`) to exclude every method on a client:
+
+```yaml
+exclusions:
+  - package: core
+    client: CatalogClient
+    reason: read-only catalog search, no CRUD lifecycle
+  - package: core
+    client: WorkspacesClient
+    method: ProvisionIdentity
+    reason: action-style operation, not a resource
+```
+
+You do **not** need to exclude methods that are already used by an existing
+resource — those are detected automatically from the provider source.
+
+## CI
+
+The `test-gaptools` job in `.github/workflows/test.yml` runs the tool's unit
+tests (via `task test:gaptools`) whenever `tools/**` changes. Run the audit
+locally with the commands above before adding new SDK-backed resources.

--- a/tools/gapcheck/coverage_synth_test.go
+++ b/tools/gapcheck/coverage_synth_test.go
@@ -1,0 +1,192 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
+)
+
+// fakeSDKCore is a minimal stand-in for a fabric-sdk-go client package. Its
+// import path (github.com/microsoft/fabric-sdk-go/fabric/core) is what makes
+// collectCoveredCalls treat calls into it as SDK calls.
+const fakeSDKCore = `package core
+
+type FooClient struct{}
+
+func (c *FooClient) GetFoo() string   { return "" }
+func (c *FooClient) ListFoos() string { return "" }
+
+func NewFooClient() *FooClient { return &FooClient{} }
+
+// FooResponse is an SDK-path type whose methods are NOT client methods.
+type FooResponse struct{}
+
+func (r *FooResponse) Value() string { return "" }
+
+// Helper is a package-level SDK function (no receiver).
+func Helper() string { return "" }
+`
+
+// fakeService calls the fake SDK through every shape collectCoveredCalls must
+// handle. Each call is annotated with the expected outcome.
+const fakeService = `package svc
+
+import fabcore "github.com/microsoft/fabric-sdk-go/fabric/core"
+
+// wrapper embeds the SDK client so its methods are promoted.
+type wrapper struct {
+	*fabcore.FooClient
+}
+
+// localGetter is a service-local interface (declared outside the SDK path).
+type localGetter interface {
+	GetFoo() string
+}
+
+func bareVariable() {
+	c := fabcore.NewFooClient()
+	_ = c.GetFoo() // RECORDED: core/FooClient/GetFoo
+}
+
+func valueReceiverAndList() {
+	var c fabcore.FooClient
+	_ = c.ListFoos() // RECORDED: core/FooClient/ListFoos
+}
+
+func promoted(w wrapper) {
+	_ = w.GetFoo() // RECORDED via embedding: core/FooClient/GetFoo
+}
+
+func methodValue() {
+	c := fabcore.NewFooClient()
+	f := c.GetFoo
+	_ = f() // NOT recorded: call target is an identifier, not a selector
+}
+
+func viaLocalInterface(g localGetter) {
+	_ = g.GetFoo() // NOT recorded: resolves to svc.localGetter, off the SDK path
+}
+
+func nonClientReceiver(r *fabcore.FooResponse) {
+	_ = r.Value() // NOT recorded: receiver type does not end in "Client"
+}
+
+func packageLevelFunc() {
+	_ = fabcore.Helper() // NOT recorded: no receiver
+}
+`
+
+// writeSyntheticModules lays out two local modules under dir: a fake fabric-sdk
+// module and a caller module that requires it via a local replace. Returning
+// the caller module dir lets packages.Load type-check the realistic shape where
+// the caller's import path does NOT start with the SDK module path.
+func writeSyntheticModules(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	sdkDir := filepath.Join(dir, "sdk")
+	coreDir := filepath.Join(sdkDir, "fabric", "core")
+	svcDir := filepath.Join(dir, "svc")
+
+	for _, d := range []string{coreDir, svcDir} {
+		err := os.MkdirAll(d, 0o750)
+		if err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	files := map[string]string{
+		filepath.Join(sdkDir, "go.mod"):   "module " + toolutil.SDKModulePath + "\n\ngo 1.23\n",
+		filepath.Join(coreDir, "core.go"): fakeSDKCore,
+		filepath.Join(svcDir, "go.mod"):   "module example.com/svc\n\ngo 1.23\n\nrequire " + toolutil.SDKModulePath + " v0.0.0\n\nreplace " + toolutil.SDKModulePath + " => ../sdk\n",
+		filepath.Join(svcDir, "svc.go"):   fakeService,
+	}
+
+	for path, content := range files {
+		err := os.WriteFile(path, []byte(content), 0o600)
+		if err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	return svcDir
+}
+
+// Test_collectCoveredCalls_shapes deterministically verifies which SDK call
+// shapes collectCoveredCalls resolves, using a tiny synthetic module pair. It
+// type-checks in well under a second — unlike the whole-SDK integration test —
+// and pins the resolution behaviour (embedded/value/bare-variable) plus the
+// documented limitations (method values, service-local interfaces, non-client
+// receivers, package-level funcs).
+func Test_collectCoveredCalls_shapes(t *testing.T) {
+	t.Parallel()
+
+	svcDir := writeSyntheticModules(t)
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
+			packages.NeedDeps,
+		Dir: svcDir,
+	}
+
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("packages.Load: %v", err)
+	}
+
+	covered := map[string]struct{}{}
+
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			for _, e := range pkg.Errors {
+				t.Errorf("package %s: %v", pkg.PkgPath, e)
+			}
+
+			t.FailNow()
+		}
+
+		for _, file := range pkg.Syntax {
+			collectCoveredCalls(pkg, file, covered)
+		}
+	}
+
+	wantPresent := []string{
+		"core/FooClient/GetFoo",   // bare variable + promoted (embedding)
+		"core/FooClient/ListFoos", // value receiver
+	}
+	for _, key := range wantPresent {
+		if _, ok := covered[key]; !ok {
+			t.Errorf("expected %q to be recorded as covered; got keys %v", key, keysOf(covered))
+		}
+	}
+
+	// Shapes that must NOT be recorded. Value() is the only other selector call
+	// into the SDK path, so any leakage would show up as an extra key.
+	if _, ok := covered["core/FooResponse/Value"]; ok {
+		t.Error("non-client receiver FooResponse.Value must not be recorded")
+	}
+
+	// The only recordable keys are the two client methods; method values,
+	// local-interface dispatch, and package-level funcs contribute nothing.
+	if len(covered) != len(wantPresent) {
+		t.Errorf("covered has unexpected extra keys: got %v, want exactly %v", keysOf(covered), wantPresent)
+	}
+}
+
+func keysOf(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/tools/gapcheck/exclusions.yaml
+++ b/tools/gapcheck/exclusions.yaml
@@ -1,0 +1,217 @@
+# Exclusions for gapcheck — SDK methods that will NOT be implemented as
+# Terraform resources.
+#
+# For methods that are implemented as part of an existing resource, the tool
+# auto-detects them by scanning service code for SDK method calls.
+#
+# Format: package/client/method → reason
+# Use method: "*" (or omit method) to exclude all methods on a client.
+
+exclusions:
+  - package: core
+    client: LongRunningOperationsClient
+    reason: internal LRO polling, not a user-facing resource
+  - package: core
+    client: CatalogClient
+    reason: read-only catalog search, no CRUD lifecycle
+  - package: core
+    client: OneLakeSettingsClient
+    reason: action-style modify operations, no create/delete lifecycle
+  - package: core
+    client: ExternalDataSharesRecipientClient
+    reason: accept invitation action, no CRUD lifecycle
+  - package: admin
+    client: ExternalDataSharesProviderClient
+    reason: admin-level listing and revoke actions
+  - package: admin
+    client: LabelsClient
+    reason: bulk label set/remove actions
+  - package: admin
+    client: SharingLinksClient
+    reason: bulk sharing link removal actions
+  - package: admin
+    client: ItemsClient
+    reason: admin-level item enumeration, no CRUD
+  - package: admin
+    client: UsersClient
+    reason: admin-level user access enumeration
+  - package: admin
+    client: WorkspacesClient
+    reason: admin-level workspace actions, not CRUD resources
+  - package: admin
+    client: DomainsClient
+    method: SyncRoleAssignmentsToSubdomains
+    reason: admin action, not a resource
+  - package: admin
+    client: DomainsClient
+    method: AssignDomainWorkspacesByCapacities
+    reason: admin domain workspace assignment action
+  - package: admin
+    client: DomainsClient
+    method: AssignDomainWorkspacesByPrincipals
+    reason: admin domain workspace assignment action
+  - package: admin
+    client: DomainsClient
+    method: UnassignAllDomainWorkspaces
+    reason: admin domain workspace unassignment action
+  - package: admin
+    client: DomainsClient
+    method: ListRoleAssignments
+    reason: read-only admin domain role assignment enumeration
+  - package: admin
+    client: DomainsClient
+    method: CreateDomainPreview
+    reason: preview API variant of admin domain CRUD, covered by stable CreateDomain
+  - package: admin
+    client: DomainsClient
+    method: GetDomainPreview
+    reason: preview API variant of admin domain CRUD, covered by stable GetDomain
+  - package: admin
+    client: DomainsClient
+    method: ListDomainsPreview
+    reason: preview API variant of admin domain CRUD, covered by stable ListDomains
+  - package: admin
+    client: DomainsClient
+    method: UpdateDomainPreview
+    reason: preview API variant of admin domain CRUD, covered by stable UpdateDomain
+  - package: lakehouse
+    client: BackgroundJobsClient
+    reason: data-plane background job scheduling
+  - package: lakehouse
+    client: LivySessionsClient
+    reason: data-plane Livy runtime sessions
+  - package: dataflow
+    client: BackgroundJobsClient
+    reason: data-plane background jobs
+  - package: dataflow
+    client: QueryExecutionClient
+    reason: data-plane query execution
+  - package: datapipeline
+    client: BackgroundJobsClient
+    reason: data-plane background jobs
+  - package: notebook
+    client: BackgroundJobsClient
+    reason: data-plane background jobs
+  - package: notebook
+    client: LivySessionsClient
+    reason: data-plane Livy runtime sessions
+  - package: sparkjobdefinition
+    client: BackgroundJobsClient
+    reason: data-plane background jobs
+  - package: sparkjobdefinition
+    client: LivySessionsClient
+    reason: data-plane Livy runtime sessions
+  - package: graphmodel
+    client: BackgroundJobsClient
+    reason: data-plane background jobs
+  - package: spark
+    client: LivySessionsClient
+    reason: data-plane Livy runtime sessions
+  - package: mirroredazuredatabrickscatalog
+    client: DiscoveryClient
+    reason: data-plane catalog discovery
+  - package: mirroredazuredatabrickscatalog
+    client: RefreshClient
+    reason: data-plane metadata refresh
+  - package: mirroredcatalog
+    client: DiscoveryClient
+    reason: data-plane catalog discovery
+  - package: mirroredcatalog
+    client: MonitoringClient
+    reason: data-plane mirroring monitoring
+  - package: mirroredcatalog
+    client: RefreshClient
+    reason: data-plane metadata refresh
+  - package: mirroreddatabase
+    client: MirroringClient
+    reason: data-plane mirroring start/stop
+  - package: sqldatabase
+    client: MirroringClient
+    reason: data-plane mirroring start/stop
+  - package: warehouse
+    client: RestorePointsClient
+    reason: operational restore points, no create lifecycle
+  - package: warehouse
+    client: SQLPoolsClient
+    reason: operational pool management
+  - package: mlmodel
+    client: EndpointClient
+    reason: data-plane ML model endpoint operations
+  - package: apacheairflowjob
+    client: ComputeClient
+    reason: data-plane compute operations
+  - package: realtimeintelligence
+    client: CopilotClient
+    reason: data-plane Copilot NL-to-KQL
+  - package: admin
+    client: TenantsClient
+    method: ListDomainsTenantSettingsOverrides
+    reason: admin tenant setting overrides, no CRUD resource
+  - package: core
+    client: ConnectionsClient
+    method: ListSupportedConnectionTypes
+    reason: read-only supported connection type enumeration
+  - package: core
+    client: GitClient
+    method: GetStatus
+    reason: read-only Git status introspection
+  - package: core
+    client: OneLakeShortcutsClient
+    method: CreatesShortcutsInBulk
+    reason: bulk shortcut creation action; individual shortcuts via fabric_shortcut
+  - package: core
+    client: WorkspacesClient
+    method: AssignToDomain
+    reason: workspace-to-domain assignment action; see fabric_domain_workspace_assignment
+  - package: core
+    client: WorkspacesClient
+    method: UnassignFromDomain
+    reason: workspace-from-domain unassignment action; see fabric_domain_workspace_assignment
+  - package: eventstream
+    client: TopologyClient
+    method: GetEventstreamTopology
+    reason: read-only eventstream topology introspection
+  - package: eventstream
+    client: TopologyClient
+    method: GetEventstreamDestination
+    reason: read-only eventstream topology introspection
+  - package: eventstream
+    client: TopologyClient
+    method: GetEventstreamSource
+    reason: read-only eventstream topology introspection
+  - package: eventstream
+    client: TopologyClient
+    method: PauseEventstream
+    reason: data-plane eventstream pause action
+  - package: eventstream
+    client: TopologyClient
+    method: PauseEventstreamDestination
+    reason: data-plane eventstream pause action
+  - package: eventstream
+    client: TopologyClient
+    method: PauseEventstreamSource
+    reason: data-plane eventstream pause action
+  - package: eventstream
+    client: TopologyClient
+    method: ResumeEventstream
+    reason: data-plane eventstream resume action
+  - package: eventstream
+    client: TopologyClient
+    method: ResumeEventstreamDestination
+    reason: data-plane eventstream resume action
+  - package: eventstream
+    client: TopologyClient
+    method: ResumeEventstreamSource
+    reason: data-plane eventstream resume action
+  - package: lakehouse
+    client: TablesClient
+    method: LoadTable
+    reason: data-plane table load action
+  - package: lakehouse
+    client: TablesClient
+    method: LoadSchemaTableBeta
+    reason: data-plane table load action (beta)
+  - package: spark
+    client: CustomPoolsClient
+    method: ListCapacityCustomPoolsBeta
+    reason: beta capacity-level custom pool enumeration

--- a/tools/gapcheck/main.go
+++ b/tools/gapcheck/main.go
@@ -29,7 +29,7 @@ import (
 	"unicode"
 
 	"golang.org/x/tools/go/packages"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
 )

--- a/tools/gapcheck/main.go
+++ b/tools/gapcheck/main.go
@@ -1,0 +1,1123 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Command gapcheck detects control-plane Fabric entities exposed by
+// fabric-sdk-go that have no corresponding Terraform resource in this provider.
+//
+// It classifies SDK client methods into noun-grouped operation sets and
+// identifies control-plane resources (Create+Delete, Add+Delete, or Get+Set
+// pairs) that are not yet covered by a TF resource type.
+//
+// Usage:
+//
+//	go run ./tools/gapcheck            # human-readable report
+//	go run ./tools/gapcheck -json      # machine-readable JSON output
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+
+	"golang.org/x/tools/go/packages"
+	"gopkg.in/yaml.v3"
+
+	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
+)
+
+// exit codes.
+const (
+	exitOK   = 0
+	exitGaps = 1
+	exitErr  = 2
+)
+
+// CLI flags.
+var (
+	jsonFlag       = flag.Bool("json", false, "output machine-readable JSON")                               //nolint:gochecknoglobals
+	dirFlag        = flag.String("dir", toolutil.DefaultServicesDir, "services directory to scan")          //nolint:gochecknoglobals
+	exclusionsFlag = flag.String("exclusions", "", "path to exclusions YAML file (default: auto-detected)") //nolint:gochecknoglobals
+)
+
+// nounTypeOverrides maps SDK noun (PascalCase) to TF type when the automatic
+// derivation does not match. Used for known naming mismatches.
+var nounTypeOverrides = map[string]string{ //nolint:gochecknoglobals
+	// SDK uses "CosmosDBDatabase" but TF type is "cosmos_db"
+	"CosmosDBDatabase":  "cosmos_db",
+	"CosmosDBDatabases": "cosmos_db",
+	// SDK uses "GraphQLAPI"/"GraphQLApis" but TF type is "graphql_api"
+	"GraphQLAPI":           "graphql_api",
+	"GraphQLApis":          "graphql_api",
+	"GraphQLAPIDefinition": "graphql_api",
+	// OneLake data access: SDK nouns map to "onelake_data_access_security"
+	"DataAccessRoles":      "onelake_data_access_security",
+	"DataAccessRole":       "onelake_data_access_security",
+	"SingleDataAccessRole": "onelake_data_access_security",
+	// Reflex is the old name for Activator
+	"Reflex":   "activator",
+	"Reflexes": "activator",
+	// Spark custom pools: SDK splits workspace/capacity but TF has one resource
+	"WorkspaceCustomPool":    "spark_custom_pool",
+	"WorkspaceCustomPools":   "spark_custom_pool",
+	"CapacityCustomPoolBeta": "spark_custom_pool",
+}
+
+// intentionallySkipped is no longer hard-coded — see exclusions.yaml.
+
+// exclusionEntry represents a single exclusion in the YAML file.
+type exclusionEntry struct {
+	Package string `json:"package" yaml:"package"`
+	Client  string `json:"client"  yaml:"client"`
+	Method  string `json:"method"  yaml:"method"`
+	Reason  string `json:"reason"  yaml:"reason"`
+}
+
+// exclusionKey returns the unique key for matching against noun groups.
+func (e exclusionEntry) exclusionKey() string {
+	return e.Package + "/" + e.Client + "/" + e.Method
+}
+
+// exclusionsFile is the top-level YAML structure.
+type exclusionsFile struct {
+	Exclusions []exclusionEntry `yaml:"exclusions"`
+}
+
+// loadExclusions reads the exclusions YAML file and returns a map keyed by
+// package/client/noun.
+func loadExclusions(path string) (map[string]exclusionEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading exclusions file %s: %w", path, err)
+	}
+
+	var ef exclusionsFile
+	if err := yaml.Unmarshal(data, &ef); err != nil {
+		return nil, fmt.Errorf("parsing exclusions file %s: %w", path, err)
+	}
+
+	result := make(map[string]exclusionEntry, len(ef.Exclusions))
+
+	for _, e := range ef.Exclusions {
+		if e.Package == "" || e.Client == "" || e.Reason == "" {
+			return nil, fmt.Errorf("exclusion entry missing required field (package, client, reason): %+v", e)
+		}
+
+		// If method is empty or "*", it excludes all methods on the client.
+		if e.Method == "" {
+			e.Method = "*"
+		}
+
+		result[e.exclusionKey()] = e
+	}
+
+	return result, nil
+}
+
+// lookupExclusion checks if a method is excluded, either by exact match or
+// by client-level wildcard (method="*").
+func lookupExclusion(exclusions map[string]exclusionEntry, m sdkMethod) (exclusionEntry, bool) {
+	// Try exact match first.
+	if entry, ok := exclusions[m.sdkMethodExclKey()]; ok {
+		return entry, true
+	}
+
+	// Try client-level wildcard.
+	wildcardKey := m.Package + "/" + m.Client + "/*"
+	if entry, ok := exclusions[wildcardKey]; ok {
+		return entry, true
+	}
+
+	return exclusionEntry{}, false
+}
+
+// actionVerbs are verbs that never contribute to control-plane classification.
+var actionVerbs = map[string]struct{}{ //nolint:gochecknoglobals
+	"Begin":     {},
+	"Test":      {},
+	"Run":       {},
+	"Execute":   {},
+	"Query":     {},
+	"Submit":    {},
+	"Cancel":    {},
+	"Move":      {},
+	"Sync":      {},
+	"Revoke":    {},
+	"Accept":    {},
+	"Reset":     {},
+	"Associate": {},
+	"New":       {}, // pager constructors
+}
+
+// sortedActionVerbs is actionVerbs as a sorted slice for deterministic iteration.
+var sortedActionVerbs = func() []string { //nolint:gochecknoglobals
+	keys := make([]string, 0, len(actionVerbs))
+	for k := range actionVerbs {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}()
+
+func main() {
+	flag.Parse()
+	os.Exit(run())
+}
+
+func run() int {
+	root, err := toolutil.ModuleRoot()
+	if err != nil {
+		toolutil.Errf("error: %v\n", err)
+
+		return exitErr
+	}
+
+	sdkDir, err := sdkFabricDir(root)
+	if err != nil {
+		toolutil.Errf("error resolving SDK: %v\n", err)
+
+		return exitErr
+	}
+
+	// Resolve exclusions file path.
+	exclusionsPath := *exclusionsFlag
+	if exclusionsPath == "" {
+		// Default: tools/gapcheck/exclusions.yaml relative to module root.
+		exclusionsPath = filepath.Join(root, "tools", "gapcheck", "exclusions.yaml")
+	}
+
+	exclusions, err := loadExclusions(exclusionsPath)
+	if err != nil {
+		toolutil.Errf("error loading exclusions: %v\n", err)
+
+		return exitErr
+	}
+
+	// 1. Extract noun groups from SDK clients.
+	nounGroups, err := extractNounGroups(sdkDir)
+	if err != nil {
+		toolutil.Errf("error extracting SDK methods: %v\n", err)
+
+		return exitErr
+	}
+
+	// 2. Build TF resource inventory.
+	inventory, err := buildInventory(root, *dirFlag)
+	if err != nil {
+		toolutil.Errf("error building inventory: %v\n", err)
+
+		return exitErr
+	}
+
+	// 3. Detect which SDK methods are actually called in service implementations.
+	calledMethods, err := extractCoveredMethods(root, *dirFlag)
+	if err != nil {
+		toolutil.Errf("error detecting covered methods: %v\n", err)
+
+		return exitErr
+	}
+
+	// 4. Extract ALL SDK methods for completeness checking.
+	allMethods, err := extractAllMethods(sdkDir)
+	if err != nil {
+		toolutil.Errf("error extracting SDK methods: %v\n", err)
+
+		return exitErr
+	}
+
+	// 4. Classify and diff.
+	gaps := findGaps(nounGroups, allMethods, inventory, exclusions, calledMethods)
+
+	// 5. Report.
+	return report(gaps)
+}
+
+// nounGroup represents a classified SDK operation group.
+type nounGroup struct {
+	Package string   `json:"package"`
+	Client  string   `json:"client"`
+	Noun    string   `json:"noun"`
+	Verbs   []string `json:"verbs"`
+	Kind    string   `json:"kind"` // "resource", "singleton"
+}
+
+// gap represents an SDK method that is not covered by a TF resource.
+type gap struct {
+	SDKMethod sdkMethod `json:"sdk_method"`
+	Verb      string    `json:"verb,omitempty"`
+	Skipped   string    `json:"skipped,omitempty"`
+	Stale     bool      `json:"stale,omitempty"`
+	Covered   bool      `json:"covered,omitempty"`
+}
+
+// sdkMethod represents a single SDK client method.
+type sdkMethod struct {
+	Package string `json:"package"`
+	Client  string `json:"client"`
+	Method  string `json:"method"`
+}
+
+// sdkMethodExclKey returns the exclusion key for an sdkMethod.
+func (m sdkMethod) sdkMethodExclKey() string {
+	return m.Package + "/" + m.Client + "/" + m.Method
+}
+
+// extractCoveredMethods type-checks the service packages under servicesDir and
+// returns the set of package/client/method keys for every fabric-sdk-go client
+// method they invoke.
+//
+// It uses go/packages type resolution (not regex) so that calls made through
+// local variables, function parameters, cross-file client fields, import
+// aliases, or embedded types are all resolved to the exact SDK method they
+// reference. Keys are formatted "sdkPackage/ClientType/Method" to match
+// sdkMethod.sdkMethodExclKey.
+func extractCoveredMethods(root, servicesDir string) (map[string]struct{}, error) {
+	pkgs, err := toolutil.LoadServicePackages(root, servicesDir)
+	if err != nil {
+		return nil, err
+	}
+
+	covered := map[string]struct{}{}
+
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			for _, e := range pkg.Errors {
+				toolutil.Errf("package %s: %v\n", pkg.PkgPath, e)
+			}
+
+			return nil, fmt.Errorf("type-checking failed for package %s", pkg.PkgPath)
+		}
+
+		for _, file := range pkg.Syntax {
+			collectCoveredCalls(pkg, file, covered)
+		}
+	}
+
+	return covered, nil
+}
+
+// collectCoveredCalls walks call expressions in file, resolves each callee via
+// the type checker, and records every fabric-sdk-go client method it finds in
+// covered as "sdkPackage/ClientType/Method".
+func collectCoveredCalls(pkg *packages.Package, file *ast.File, covered map[string]struct{}) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		// SDK methods are always reached through a selector: x.Method(...).
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		fn, ok := pkg.TypesInfo.ObjectOf(sel.Sel).(*types.Func)
+		if !ok || fn.Pkg() == nil {
+			return true
+		}
+
+		if !strings.HasPrefix(fn.Pkg().Path(), toolutil.SDKModulePath) {
+			return true
+		}
+
+		sig, ok := fn.Type().(*types.Signature)
+		if !ok || sig.Recv() == nil {
+			return true // package-level SDK func, not a client method
+		}
+
+		clientType := receiverTypeName(sig.Recv().Type())
+		if !strings.HasSuffix(clientType, "Client") {
+			return true
+		}
+
+		// The SDK directory name (used by extractAllMethods) is the last element
+		// of the import path, which is also the package name in fabric-sdk-go.
+		sdkPkg := fn.Pkg().Path()
+		if i := strings.LastIndex(sdkPkg, "/"); i >= 0 {
+			sdkPkg = sdkPkg[i+1:]
+		}
+
+		covered[sdkPkg+"/"+clientType+"/"+fn.Name()] = struct{}{}
+
+		return true
+	})
+}
+
+// receiverTypeName returns the bare type name of a method receiver, unwrapping
+// a pointer receiver (e.g. *fabcore.WorkspacesClient -> "WorkspacesClient").
+func receiverTypeName(t types.Type) string {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+
+	if named, ok := t.(*types.Named); ok {
+		return named.Obj().Name()
+	}
+
+	return ""
+}
+
+// extractAllMethods scans SDK client files and returns every public method
+// (excluding internal helpers, pager constructors, and Begin* LRO twins).
+func extractAllMethods(sdkDir string) ([]sdkMethod, error) {
+	var results []sdkMethod
+
+	entries, err := os.ReadDir(sdkDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == "fake" {
+			continue
+		}
+
+		pkgDir := filepath.Join(sdkDir, e.Name())
+
+		pkgEntries, readErr := os.ReadDir(pkgDir)
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", e.Name(), readErr)
+		}
+
+		for _, f := range pkgEntries {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), "_client.go") || strings.Contains(f.Name(), "example") {
+				continue
+			}
+
+			data, fileErr := os.ReadFile(filepath.Join(pkgDir, f.Name()))
+			if fileErr != nil {
+				return nil, fmt.Errorf("reading %s/%s: %w", e.Name(), f.Name(), fileErr)
+			}
+
+			for line := range strings.SplitSeq(string(data), "\n") {
+				client, method := parseClientMethod(line)
+				if client == "" {
+					continue
+				}
+
+				// Skip Begin* LRO twins (the sync version is tracked).
+				if strings.HasPrefix(method, "Begin") {
+					continue
+				}
+
+				// Skip pager constructors.
+				if strings.HasPrefix(method, "New") && strings.Contains(method, "Pager") {
+					continue
+				}
+
+				// Skip core.ItemsClient (generic fan-out).
+				if e.Name() == "core" && client == "ItemsClient" {
+					continue
+				}
+
+				results = append(results, sdkMethod{
+					Package: e.Name(),
+					Client:  client,
+					Method:  method,
+				})
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// extractNounGroups scans all *_client.go files in the SDK fabric/ directory
+// (core + per-item packages) and returns classified noun groups that look like
+// control-plane resources.
+func extractNounGroups(sdkDir string) ([]nounGroup, error) {
+	var results []nounGroup
+
+	// Scan core package.
+	coreGroups, err := scanPackageClients(filepath.Join(sdkDir, "core"), "core")
+	if err != nil {
+		return nil, fmt.Errorf("scanning core: %w", err)
+	}
+
+	results = append(results, coreGroups...)
+
+	// Scan per-item packages (non-ItemsClient clients that have control-plane signatures).
+	entries, err := os.ReadDir(sdkDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == "core" || e.Name() == "fake" {
+			continue
+		}
+
+		pkgDir := filepath.Join(sdkDir, e.Name())
+
+		groups, scanErr := scanPackageClients(pkgDir, e.Name())
+		if scanErr != nil {
+			return nil, fmt.Errorf("scanning package %s: %w", e.Name(), scanErr)
+		}
+
+		results = append(results, groups...)
+	}
+
+	return results, nil
+}
+
+// scanPackageClients reads all *_client.go files in a directory, extracts method
+// names per client, and classifies noun groups.
+func scanPackageClients(dir, pkgName string) ([]nounGroup, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect methods per client.
+	clientMethods := map[string][]string{}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_client.go") || strings.Contains(e.Name(), "example") {
+			continue
+		}
+
+		data, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", e.Name(), readErr)
+		}
+
+		for line := range strings.SplitSeq(string(data), "\n") {
+			client, method := parseClientMethod(line)
+			if client == "" {
+				continue
+			}
+
+			clientMethods[client] = append(clientMethods[client], method)
+		}
+	}
+
+	var results []nounGroup
+
+	for client, methods := range clientMethods {
+		// Skip the generic core.ItemsClient (per-item packages cover individual items).
+		if pkgName == "core" && client == "ItemsClient" {
+			continue
+		}
+
+		groups := classifyMethods(pkgName, client, methods)
+		results = append(results, groups...)
+	}
+
+	return results, nil
+}
+
+// parseClientMethod extracts the client type and method name from an SDK client
+// method declaration line, restricted to *…Client receivers and excluding the
+// generated request/response helpers.
+func parseClientMethod(line string) (string, string) {
+	recvType, method := toolutil.ParseClientMethod(line)
+	if recvType == "" || !strings.HasSuffix(recvType, "Client") {
+		return "", ""
+	}
+
+	// Skip internal helpers.
+	if strings.HasSuffix(method, "CreateRequest") || strings.HasSuffix(method, "HandleResponse") {
+		return "", ""
+	}
+
+	return recvType, method
+}
+
+// classifyMethods groups methods by noun, classifies each noun group, and
+// returns those that qualify as control-plane resources.
+func classifyMethods(pkg, client string, methods []string) []nounGroup {
+	// Build noun → verb set.
+	nounVerbs := map[string]map[string]struct{}{}
+
+	for _, method := range methods {
+		verb, noun := splitVerbNoun(method)
+		if verb == "" || noun == "" {
+			continue
+		}
+
+		// For Begin* LRO wrappers, re-parse the inner method to extract
+		// the real verb+noun. This handles future LRO-only resources that
+		// may not have a synchronous twin.
+		if verb == "Begin" {
+			verb, noun = splitVerbNoun(noun)
+			if verb == "" || noun == "" {
+				continue
+			}
+		}
+
+		// Skip action verbs entirely.
+		if isActionVerb(verb) {
+			continue
+		}
+
+		if _, ok := nounVerbs[noun]; !ok {
+			nounVerbs[noun] = map[string]struct{}{}
+		}
+
+		nounVerbs[noun][verb] = struct{}{}
+	}
+
+	var results []nounGroup
+
+	for noun, verbs := range nounVerbs {
+		kind := classifyNounKind(verbs)
+		if kind == "" {
+			continue
+		}
+
+		verbList := toolutil.SortedKeys(verbs)
+
+		results = append(results, nounGroup{
+			Package: pkg,
+			Client:  client,
+			Noun:    noun,
+			Verbs:   verbList,
+			Kind:    kind,
+		})
+	}
+
+	return results
+}
+
+// classifyNounKind determines if a noun group qualifies as a control-plane
+// resource based on its verb signature.
+func classifyNounKind(verbs map[string]struct{}) string {
+	_, hasCreate := verbs["Create"]
+	_, hasCreateOrUpdate := verbs["CreateOrUpdate"]
+	_, hasDelete := verbs["Delete"]
+	_, hasAdd := verbs["Add"]
+	_, hasGet := verbs["Get"]
+	_, hasSet := verbs["Set"]
+
+	switch {
+	case (hasCreate || hasCreateOrUpdate) && hasDelete:
+		return "resource"
+	case hasAdd && hasDelete:
+		return "resource"
+	case hasGet && hasSet:
+		return "singleton"
+	default:
+		return ""
+	}
+}
+
+// splitVerbNoun splits a PascalCase method name into its leading verb and the
+// remaining noun. Returns empty strings for unrecognized shapes.
+func splitVerbNoun(method string) (string, string) {
+	// Try multi-word verbs first.
+	if after, ok := strings.CutPrefix(method, "CreateOrUpdate"); ok {
+		noun := after
+		if noun != "" {
+			return "CreateOrUpdate", noun
+		}
+	}
+
+	// Try known control verbs.
+	for _, v := range []string{"Create", "Delete", "Get", "Set", "Add", "Update", "List"} {
+		if after, ok := strings.CutPrefix(method, v); ok {
+			noun := after
+			if noun != "" {
+				return v, noun
+			}
+		}
+	}
+
+	// Try action verbs (iterated in sorted order for determinism).
+	for _, v := range sortedActionVerbs {
+		if after, ok := strings.CutPrefix(method, v); ok {
+			return v, after
+		}
+	}
+
+	return "", ""
+}
+
+func isActionVerb(verb string) bool {
+	_, ok := actionVerbs[verb]
+
+	return ok
+}
+
+// findGaps determines which classified noun groups are not covered by the TF inventory.
+// findGaps determines which SDK methods are not accounted for — either covered
+// by a TF resource (via noun-group matching) or excluded in exclusions.yaml.
+func findGaps(nounGroups []nounGroup, allMethods []sdkMethod, inventory map[string]struct{}, exclusions map[string]exclusionEntry, calledMethods map[string]struct{}) []gap {
+	// Build coverage sets.
+	// coveredClients: for per-item ItemsClients, if any noun matches TF inventory
+	// the entire client is covered (one resource = one ItemsClient).
+	// coveredNouns: for multi-resource clients (e.g. core.WorkspacesClient),
+	// track individual noun coverage.
+	coveredClients := map[string]struct{}{} // key: pkg/client
+	coveredNouns := map[string]struct{}{}   // key: pkg/client/noun
+
+	for _, ng := range nounGroups {
+		candidates := buildCandidates(ng)
+
+		for _, c := range candidates {
+			if _, ok := inventory[c]; ok {
+				if ng.Client == "ItemsClient" {
+					// Per-item package: entire client is one resource.
+					coveredClients[ng.Package+"/"+ng.Client] = struct{}{}
+				}
+
+				coveredNouns[ng.Package+"/"+ng.Client+"/"+ng.Noun] = struct{}{}
+
+				break
+			}
+		}
+	}
+
+	// Also mark per-item packages as covered if their package name matches
+	// any TF inventory type (handles List-only data sources like dashboard).
+	for _, m := range allMethods {
+		if m.Client != "ItemsClient" {
+			continue
+		}
+
+		clientKey := m.Package + "/" + m.Client
+		if _, ok := coveredClients[clientKey]; ok {
+			continue // already covered
+		}
+
+		// Check if the package name (or its snake_case) matches an inventory type.
+		pkgSnake := pascalToSnake(m.Package)
+		if _, ok := inventory[pkgSnake]; ok {
+			coveredClients[clientKey] = struct{}{}
+
+			continue
+		}
+
+		// Fall back to the SDK method noun. Compound package directories are
+		// lowercase concatenations (e.g. "paginatedreport"), so pascalToSnake
+		// leaves them unchanged and misses inventory types like "paginated_report".
+		// The method noun (e.g. "PaginatedReports") snake-converts correctly.
+		for _, c := range itemNounCandidates(m.Method) {
+			if _, ok := inventory[c]; ok {
+				coveredClients[clientKey] = struct{}{}
+
+				break
+			}
+		}
+	}
+
+	// For each SDK method, check if it is covered or excluded.
+	//
+	// Gap reporting is intentionally exhaustive and method-level: every SDK
+	// method that is not covered, not an action verb, and not excluded is
+	// reported — including read-only (Get/List) and update-only methods. The
+	// verb-signature classifier (classifyNounKind) governs coverage matching
+	// only; it deliberately does NOT filter this report. The goal is that every
+	// SDK operation is explicitly accounted for (implemented, excluded with a
+	// reason, or a pending gap), so the noise is pruned via exclusions.yaml
+	// rather than by narrowing what is enumerated here. See README.md.
+	var gaps []gap
+
+	for _, m := range allMethods {
+		// Determine which noun group this method belongs to (if any).
+		verb, noun := splitVerbNoun(m.Method)
+
+		// Check if the entire client is covered (per-item packages).
+		clientKey := m.Package + "/" + m.Client
+		if _, ok := coveredClients[clientKey]; ok {
+			// Method is covered. Check for stale exclusion.
+			if entry, ok := lookupExclusion(exclusions, m); ok {
+				gaps = append(gaps, gap{
+					SDKMethod: m,
+					Verb:      verb,
+					Skipped:   entry.Reason,
+					Stale:     true,
+				})
+			}
+
+			continue
+		}
+
+		// Check if this specific method is called in a service implementation.
+		methodKey := m.sdkMethodExclKey()
+		if _, ok := calledMethods[methodKey]; ok {
+			// Method is called in service code. Check for stale exclusion.
+			if entry, ok := lookupExclusion(exclusions, m); ok {
+				gaps = append(gaps, gap{
+					SDKMethod: m,
+					Verb:      verb,
+					Skipped:   entry.Reason,
+					Stale:     true,
+				})
+			}
+
+			continue
+		}
+
+		// Check noun-level coverage (for multi-resource clients like WorkspacesClient).
+		if noun != "" {
+			// Try the noun as-is and its singular/plural variants.
+			nounVariants := []string{noun, strings.TrimSuffix(noun, "s")}
+			if !strings.HasSuffix(noun, "s") {
+				nounVariants = append(nounVariants, noun+"s")
+			}
+
+			covered := false
+
+			for _, nv := range nounVariants {
+				nounKey := m.Package + "/" + m.Client + "/" + nv
+				if _, ok := coveredNouns[nounKey]; ok {
+					covered = true
+
+					break
+				}
+			}
+
+			if covered {
+				// Method is covered. Check for stale exclusion.
+				if entry, ok := lookupExclusion(exclusions, m); ok {
+					gaps = append(gaps, gap{
+						SDKMethod: m,
+						Verb:      verb,
+						Skipped:   entry.Reason,
+						Stale:     true,
+					})
+				}
+
+				continue
+			}
+		}
+
+		// Action-style methods (Run, Cancel, Sync, etc.) are never
+		// control-plane resources, so they can never be gaps. classifyMethods
+		// already excludes them from noun-group classification; mirror that here
+		// so an uncovered action method is not misreported as a gap.
+		if isActionVerb(verb) {
+			continue
+		}
+
+		// Check if excluded — by exact method or by client wildcard.
+		if entry, ok := lookupExclusion(exclusions, m); ok {
+			gaps = append(gaps, gap{
+				SDKMethod: m,
+				Verb:      verb,
+				Skipped:   entry.Reason,
+			})
+
+			continue
+		}
+
+		// Not covered and not excluded — this is a real gap.
+		gaps = append(gaps, gap{
+			SDKMethod: m,
+			Verb:      verb,
+		})
+	}
+
+	slices.SortFunc(gaps, func(a, b gap) int {
+		if c := strings.Compare(a.SDKMethod.Package, b.SDKMethod.Package); c != 0 {
+			return c
+		}
+
+		if c := strings.Compare(a.SDKMethod.Client, b.SDKMethod.Client); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.SDKMethod.Method, b.SDKMethod.Method)
+	})
+
+	return gaps
+}
+
+// itemNounCandidates derives candidate TF type strings from a per-item
+// ItemsClient method by extracting its noun. This lets compound package
+// directories (e.g. "paginatedreport", "mirroredwarehouse") match inventory
+// types ("paginated_report", "mirrored_warehouse") that the lowercase package
+// name alone cannot produce via pascalToSnake.
+func itemNounCandidates(method string) []string {
+	_, noun := splitVerbNoun(method)
+	if noun == "" {
+		return nil
+	}
+
+	if override, ok := nounTypeOverrides[noun]; ok {
+		return []string{override}
+	}
+
+	bareNoun := pascalToSnake(noun)
+	bareSingular := strings.TrimSuffix(bareNoun, "s")
+
+	if bareNoun == bareSingular {
+		return []string{bareSingular}
+	}
+
+	return []string{bareSingular, bareNoun}
+}
+
+// buildCandidates generates the multi-candidate type strings for matching:
+// 1. explicit override (if present)
+// 2. bare noun → snake_case (singular)
+// 3. bare noun → snake_case (plural, for "rules" style resources)
+// 4. client-entity prefix + noun (singular)
+// 5. client-entity prefix + noun (plural)
+func buildCandidates(ng nounGroup) []string {
+	// Check for explicit override first.
+	if override, ok := nounTypeOverrides[ng.Noun]; ok {
+		return []string{override}
+	}
+
+	bareNoun := pascalToSnake(ng.Noun)
+
+	// Normalize plurals for list-derived nouns.
+	bareSingular := strings.TrimSuffix(bareNoun, "s")
+
+	// Derive prefix from client name: "WorkspacesClient" → "workspace"
+	clientEntity := strings.TrimSuffix(ng.Client, "Client")
+	clientEntity = strings.TrimSuffix(clientEntity, "s") // WorkspacesClient → Workspace
+	prefix := pascalToSnake(clientEntity)
+
+	prefixedSingular := prefix + "_" + bareSingular
+	prefixedPlural := prefix + "_" + bareNoun
+
+	seen := map[string]struct{}{}
+	var candidates []string
+
+	add := func(c string) {
+		if _, ok := seen[c]; !ok {
+			seen[c] = struct{}{}
+			candidates = append(candidates, c)
+		}
+	}
+
+	add(bareSingular)
+
+	if bareNoun != bareSingular {
+		add(bareNoun) // plural form
+	}
+
+	add(prefixedSingular)
+
+	if prefixedPlural != prefixedSingular {
+		add(prefixedPlural)
+	}
+
+	return candidates
+}
+
+// buildInventory collects all TF resource Type values from base.go files.
+// Every service package is expected to have a base.go declaring its TFTypeInfo.
+func buildInventory(root, servicesDir string) (map[string]struct{}, error) {
+	servicesPath := filepath.Join(root, servicesDir)
+	inventory := map[string]struct{}{}
+
+	entries, err := os.ReadDir(servicesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	typeRe := regexp.MustCompile(`Type:\s*"([a-z_]+)"`)
+
+	var missing []string
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		baseFile := filepath.Join(servicesPath, e.Name(), "base.go")
+
+		data, readErr := os.ReadFile(baseFile)
+		if readErr != nil {
+			missing = append(missing, e.Name())
+
+			continue
+		}
+
+		matches := typeRe.FindAllSubmatch(data, -1)
+		for _, m := range matches {
+			inventory[string(m[1])] = struct{}{}
+		}
+	}
+
+	if len(missing) > 0 {
+		toolutil.Errf("warning: %d service packages have no base.go: %s\n", len(missing), strings.Join(missing, ", "))
+	}
+
+	if len(inventory) == 0 {
+		return nil, fmt.Errorf("no TF types found in %s — check services directory", servicesPath)
+	}
+
+	return inventory, nil
+}
+
+func report(gaps []gap) int {
+	if *jsonFlag {
+		return reportJSON(gaps)
+	}
+
+	return reportHuman(gaps)
+}
+
+func reportJSON(gaps []gap) int {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+
+	err := enc.Encode(gaps)
+	if err != nil {
+		toolutil.Errf("error encoding JSON: %v\n", err)
+
+		return exitErr
+	}
+
+	realGaps := countRealGaps(gaps)
+	if realGaps > 0 {
+		return exitGaps
+	}
+
+	return exitOK
+}
+
+func reportHuman(gaps []gap) int {
+	var real, excluded, stale []gap
+
+	for _, g := range gaps {
+		switch {
+		case g.Stale:
+			stale = append(stale, g)
+		case g.Skipped != "":
+			excluded = append(excluded, g)
+		default:
+			real = append(real, g)
+		}
+	}
+
+	if len(real) > 0 {
+		toolutil.Outf("GAPS — SDK methods with no TF coverage and no exclusion:\n\n")
+
+		prevClient := ""
+
+		for _, g := range real {
+			currClient := g.SDKMethod.Package + "/" + g.SDKMethod.Client
+			if prevClient != "" && currClient != prevClient {
+				toolutil.Outf("\n")
+			}
+
+			toolutil.Outf("  %s/%s.%s\n", g.SDKMethod.Package, g.SDKMethod.Client, g.SDKMethod.Method)
+
+			prevClient = currClient
+		}
+	}
+
+	if len(excluded) > 0 {
+		toolutil.Outf("\nEXCLUDED (per exclusions.yaml): %d methods\n", len(excluded))
+	}
+
+	if len(stale) > 0 {
+		toolutil.Outf("\nSTALE EXCLUSIONS — now implemented, remove from exclusions.yaml:\n\n")
+
+		for _, g := range stale {
+			toolutil.Outf("  %s/%s.%s\n", g.SDKMethod.Package, g.SDKMethod.Client, g.SDKMethod.Method)
+		}
+	}
+
+	toolutil.Outf("\nSummary: %d gaps, %d excluded, %d stale\n", len(real), len(excluded), len(stale))
+
+	if len(real) > 0 || len(stale) > 0 {
+		return exitGaps
+	}
+
+	return exitOK
+}
+
+func countRealGaps(gaps []gap) int {
+	count := 0
+
+	for _, g := range gaps {
+		if g.Skipped == "" || g.Stale {
+			count++
+		}
+	}
+
+	return count
+}
+
+// sdkFabricDir resolves the fabric-sdk-go module's fabric/ directory.
+func sdkFabricDir(root string) (string, error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", toolutil.SDKModulePath)
+	cmd.Dir = root
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("go list -m: %w", err)
+	}
+
+	modDir := strings.TrimSpace(string(out))
+	fabricDir := filepath.Join(modDir, "fabric")
+
+	if _, statErr := os.Stat(fabricDir); statErr != nil {
+		return "", fmt.Errorf("fabric dir not found at %s: %w", fabricDir, statErr)
+	}
+
+	return fabricDir, nil
+}
+
+// pascalToSnake converts PascalCase to snake_case.
+// It handles runs of uppercase letters (acronyms) by keeping them together:
+// "GraphQLApi" → "graph_ql_api", "KQLDatabase" → "kql_database".
+func pascalToSnake(s string) string {
+	var result strings.Builder
+
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if !unicode.IsUpper(r) {
+			result.WriteRune(r)
+
+			continue
+		}
+
+		// We have an uppercase rune. Determine if it starts an acronym run.
+		if i > 0 {
+			result.WriteByte('_')
+		}
+
+		// Collect the run of consecutive uppercase letters.
+		j := i
+
+		for j < len(runes) && unicode.IsUpper(runes[j]) {
+			j++
+		}
+
+		runLen := j - i
+
+		if runLen == 1 {
+			// Single uppercase: just a normal word start.
+			result.WriteRune(unicode.ToLower(r))
+		} else if j == len(runes) {
+			// Uppercase run goes to end of string — entire run is the acronym.
+			for k := i; k < j; k++ {
+				result.WriteRune(unicode.ToLower(runes[k]))
+			}
+
+			i = j - 1
+		} else {
+			// Uppercase run followed by lowercase: last uppercase char starts next word.
+			// e.g. "SQLDatabase" → run is "SQLD", but "D" starts "Database".
+			for k := i; k < j-1; k++ {
+				result.WriteRune(unicode.ToLower(runes[k]))
+			}
+
+			result.WriteByte('_')
+			result.WriteRune(unicode.ToLower(runes[j-1]))
+			i = j - 1
+		}
+	}
+
+	return result.String()
+}

--- a/tools/gapcheck/main_test.go
+++ b/tools/gapcheck/main_test.go
@@ -1,0 +1,728 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
+)
+
+func Test_pascalToSnake(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Workspace", "workspace"},
+		{"WorkspaceRoleAssignment", "workspace_role_assignment"},
+		{"GitOutboundPolicy", "git_outbound_policy"},
+		{"NetworkCommunicationPolicy", "network_communication_policy"},
+		{"ManagedPrivateEndpoint", "managed_private_endpoint"},
+		{"ExternalDataShare", "external_data_share"},
+		{"Lakehouse", "lakehouse"},
+		// Acronym runs.
+		{"KQLDatabase", "kql_database"},
+		{"KQLDashboard", "kql_dashboard"},
+		{"KQLQueryset", "kql_queryset"},
+		{"SQLDatabase", "sql_database"},
+		{"SQLEndpoint", "sql_endpoint"},
+		{"MLExperiment", "ml_experiment"},
+		{"MLModel", "ml_model"},
+		// Trailing acronym (entire run to end of string).
+		{"GraphQLAPI", "graph_qlapi"},
+		// Mixed case.
+		{"OutboundCloudConnectionRules", "outbound_cloud_connection_rules"},
+		{"InboundAzureResourceRules", "inbound_azure_resource_rules"},
+		{"CosmosDBDatabase", "cosmos_db_database"},
+		{"OneLakeDataAccessSecurity", "one_lake_data_access_security"},
+		// Simple.
+		{"Folder", "folder"},
+		{"Domain", "domain"},
+		{"Gateway", "gateway"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := pascalToSnake(tt.input)
+			if got != tt.want {
+				t.Errorf("pascalToSnake(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitVerbNoun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method   string
+		wantVerb string
+		wantNoun string
+	}{
+		{"CreateWorkspace", "Create", "Workspace"},
+		{"DeleteWorkspace", "Delete", "Workspace"},
+		{"GetGitOutboundPolicy", "Get", "GitOutboundPolicy"},
+		{"SetInboundAzureResourceRules", "Set", "InboundAzureResourceRules"},
+		{"AddWorkspaceRoleAssignment", "Add", "WorkspaceRoleAssignment"},
+		{"ListWorkspaces", "List", "Workspaces"},
+		{"UpdateWorkspace", "Update", "Workspace"},
+		{"CreateOrUpdateDataAccessRoles", "CreateOrUpdate", "DataAccessRoles"},
+		// Action verbs.
+		{"BeginCreateWorkspace", "Begin", "CreateWorkspace"},
+		{"TestConnection", "Test", "Connection"},
+		{"NewListItemsPager", "New", "ListItemsPager"},
+		// Formerly action verbs: no longer recognized, so they parse to no verb
+		// and surface as gaps to be accounted for via exclusions.yaml.
+		{"AssignToCapacity", "", ""},
+		{"ApplyTags", "", ""},
+		{"DeployStageContent", "", ""},
+		// Unrecognized.
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			t.Parallel()
+
+			gotVerb, gotNoun := splitVerbNoun(tt.method)
+			if gotVerb != tt.wantVerb || gotNoun != tt.wantNoun {
+				t.Errorf("splitVerbNoun(%q) = (%q, %q), want (%q, %q)",
+					tt.method, gotVerb, gotNoun, tt.wantVerb, tt.wantNoun)
+			}
+		})
+	}
+}
+
+func Test_classifyNounKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		verbs map[string]struct{}
+		want  string
+	}{
+		{"full CRUD", map[string]struct{}{"Create": {}, "Delete": {}, "Get": {}, "Update": {}}, "resource"},
+		{"add/delete", map[string]struct{}{"Add": {}, "Delete": {}, "Get": {}}, "resource"},
+		{"get/set singleton", map[string]struct{}{"Get": {}, "Set": {}}, "singleton"},
+		{"createOrUpdate + delete", map[string]struct{}{"CreateOrUpdate": {}, "Delete": {}, "Get": {}}, "resource"},
+		{"get only", map[string]struct{}{"Get": {}}, ""},
+		{"list only", map[string]struct{}{"List": {}}, ""},
+		{"update only", map[string]struct{}{"Update": {}}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyNounKind(tt.verbs)
+			if got != tt.want {
+				t.Errorf("classifyNounKind(%v) = %q, want %q", tt.verbs, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_itemNounCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		want   []string
+	}{
+		// Compound package dirs whose lowercase name can't snake-convert, but
+		// whose method noun can.
+		{"ListPaginatedReports", []string{"paginated_report", "paginated_reports"}},
+		{"ListMirroredWarehouses", []string{"mirrored_warehouse", "mirrored_warehouses"}},
+		// Singular noun yields a single candidate.
+		{"GetPaginatedReport", []string{"paginated_report"}},
+		// Override takes precedence over derivation.
+		{"ListReflexes", []string{"activator"}},
+		// Unrecognized method shape yields no candidates.
+		{"Frobnicate", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			t.Parallel()
+
+			got := itemNounCandidates(tt.method)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("itemNounCandidates(%q) = %v, want %v", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_findGaps_actionVerbsNotReported(t *testing.T) {
+	t.Parallel()
+
+	// Action-style methods on a client with no CRUD lifecycle must never be
+	// reported as gaps, even when neither covered nor excluded.
+	allMethods := []sdkMethod{
+		{Package: "core", Client: "ItemJobSchedulesClient", Method: "RunOnDemandItemJob"},
+		{Package: "core", Client: "ItemJobSchedulesClient", Method: "CancelItemJobInstance"},
+		// A genuine uncovered resource method should still be reported.
+		{Package: "core", Client: "WidgetsClient", Method: "CreateWidget"},
+	}
+
+	gaps := findGaps(nil, allMethods, map[string]struct{}{}, map[string]exclusionEntry{}, map[string]struct{}{})
+
+	reported := map[string]struct{}{}
+	for _, g := range gaps {
+		reported[g.SDKMethod.Method] = struct{}{}
+	}
+
+	for _, action := range []string{"RunOnDemandItemJob", "CancelItemJobInstance"} {
+		if _, ok := reported[action]; ok {
+			t.Errorf("action method %q was reported as a gap, want it skipped", action)
+		}
+	}
+
+	if _, ok := reported["CreateWidget"]; !ok {
+		t.Error("control-plane method CreateWidget was not reported as a gap")
+	}
+}
+
+// findGapFor returns the gap reported for a given method name, if any.
+func findGapFor(gaps []gap, method string) (gap, bool) {
+	for _, g := range gaps {
+		if g.SDKMethod.Method == method {
+			return g, true
+		}
+	}
+
+	return gap{}, false
+}
+
+func Test_findGaps_nounCoverage(t *testing.T) {
+	t.Parallel()
+
+	// A multi-resource client (WorkspacesClient) covers individual nouns. A
+	// method whose noun matches the inventory (directly or via singular/plural
+	// variant) must not be reported; an unrelated noun still is.
+	nounGroups := []nounGroup{
+		{Package: "core", Client: "WorkspacesClient", Noun: "Workspace"},
+	}
+	inventory := map[string]struct{}{"workspace": {}}
+	allMethods := []sdkMethod{
+		{Package: "core", Client: "WorkspacesClient", Method: "CreateWorkspace"},
+		{Package: "core", Client: "WorkspacesClient", Method: "ListWorkspaces"},
+		{Package: "core", Client: "WorkspacesClient", Method: "CreateGateway"},
+	}
+
+	gaps := findGaps(nounGroups, allMethods, inventory, map[string]exclusionEntry{}, map[string]struct{}{})
+
+	for _, covered := range []string{"CreateWorkspace", "ListWorkspaces"} {
+		if _, ok := findGapFor(gaps, covered); ok {
+			t.Errorf("method %q noun is covered, want it absent from gaps", covered)
+		}
+	}
+
+	if _, ok := findGapFor(gaps, "CreateGateway"); !ok {
+		t.Error("CreateGateway noun is not covered, want it reported as a gap")
+	}
+}
+
+func Test_findGaps_itemsClientCoverage(t *testing.T) {
+	t.Parallel()
+
+	// For a per-item ItemsClient, a single inventory match covers the entire
+	// client (one resource == one ItemsClient), so all its methods are covered.
+	nounGroups := []nounGroup{
+		{Package: "lakehouse", Client: "ItemsClient", Noun: "Lakehouse"},
+	}
+	inventory := map[string]struct{}{"lakehouse": {}}
+	allMethods := []sdkMethod{
+		{Package: "lakehouse", Client: "ItemsClient", Method: "GetLakehouse"},
+		{Package: "lakehouse", Client: "ItemsClient", Method: "GetLakehouseDefinition"},
+		{Package: "lakehouse", Client: "ItemsClient", Method: "ListLakehouses"},
+	}
+
+	gaps := findGaps(nounGroups, allMethods, inventory, map[string]exclusionEntry{}, map[string]struct{}{})
+
+	if len(gaps) != 0 {
+		t.Errorf("all ItemsClient methods should be covered, got %d gaps: %+v", len(gaps), gaps)
+	}
+}
+
+func Test_findGaps_calledMethodCoverage(t *testing.T) {
+	t.Parallel()
+
+	// A method directly resolved as called in service code (calledMethods) is
+	// covered even without any noun-group/inventory match.
+	allMethods := []sdkMethod{
+		{Package: "core", Client: "DeploymentPipelinesClient", Method: "UpdateDeploymentPipelineStage"},
+		{Package: "core", Client: "DeploymentPipelinesClient", Method: "CreateDeploymentPipeline"},
+	}
+	calledMethods := map[string]struct{}{
+		"core/DeploymentPipelinesClient/UpdateDeploymentPipelineStage": {},
+	}
+
+	gaps := findGaps(nil, allMethods, map[string]struct{}{}, map[string]exclusionEntry{}, calledMethods)
+
+	if _, ok := findGapFor(gaps, "UpdateDeploymentPipelineStage"); ok {
+		t.Error("UpdateDeploymentPipelineStage is called in service code, want it absent from gaps")
+	}
+
+	if _, ok := findGapFor(gaps, "CreateDeploymentPipeline"); !ok {
+		t.Error("CreateDeploymentPipeline is uncovered, want it reported as a gap")
+	}
+}
+
+func Test_findGaps_exclusions(t *testing.T) {
+	t.Parallel()
+
+	allMethods := []sdkMethod{
+		{Package: "core", Client: "CatalogClient", Method: "GetCatalog"},
+		{Package: "core", Client: "CatalogClient", Method: "ListCatalogs"},
+		{Package: "core", Client: "OneLakeSettingsClient", Method: "CreateOneLakeSetting"},
+	}
+	exclusions := map[string]exclusionEntry{
+		// Client-level wildcard suppresses every method on the client.
+		"core/CatalogClient/*": {Package: "core", Client: "CatalogClient", Method: "*", Reason: "read-only catalog"},
+		// Exact-method exclusion.
+		"core/OneLakeSettingsClient/CreateOneLakeSetting": {
+			Package: "core", Client: "OneLakeSettingsClient", Method: "CreateOneLakeSetting", Reason: "action-style",
+		},
+	}
+
+	gaps := findGaps(nil, allMethods, map[string]struct{}{}, exclusions, map[string]struct{}{})
+
+	for _, m := range []string{"GetCatalog", "ListCatalogs", "CreateOneLakeSetting"} {
+		g, ok := findGapFor(gaps, m)
+		if !ok {
+			t.Errorf("excluded method %q should still appear (as skipped), but is absent", m)
+
+			continue
+		}
+
+		if g.Skipped == "" {
+			t.Errorf("method %q should carry a skip reason, got empty", m)
+		}
+
+		if g.Stale {
+			t.Errorf("excluded-but-uncovered method %q must not be marked stale", m)
+		}
+	}
+}
+
+func Test_findGaps_staleExclusion(t *testing.T) {
+	t.Parallel()
+
+	// An exclusion for a method that is actually covered (here via a resolved
+	// service call) is stale and must be flagged so it can be removed.
+	allMethods := []sdkMethod{
+		{Package: "core", Client: "WorkspacesClient", Method: "CreateWorkspace"},
+	}
+	calledMethods := map[string]struct{}{
+		"core/WorkspacesClient/CreateWorkspace": {},
+	}
+	exclusions := map[string]exclusionEntry{
+		"core/WorkspacesClient/CreateWorkspace": {
+			Package: "core", Client: "WorkspacesClient", Method: "CreateWorkspace", Reason: "was skipped, now implemented",
+		},
+	}
+
+	gaps := findGaps(nil, allMethods, map[string]struct{}{}, exclusions, calledMethods)
+
+	g, ok := findGapFor(gaps, "CreateWorkspace")
+	if !ok {
+		t.Fatal("stale exclusion should be reported")
+	}
+
+	if !g.Stale {
+		t.Errorf("covered + excluded method must be marked Stale, got Stale=%v", g.Stale)
+	}
+}
+
+func Test_findGaps_readOnlyMethodsAreReported(t *testing.T) {
+	t.Parallel()
+
+	// The gap report is intentionally exhaustive: uncovered read-only (Get/List)
+	// and update-only methods MUST be reported so every SDK operation is
+	// accounted for (and pruned via exclusions.yaml, not by the classifier).
+	// This guards against narrowing findGaps to classified control-plane groups.
+	allMethods := []sdkMethod{
+		{Package: "core", Client: "DomainsClient", Method: "GetDomain"},
+		{Package: "core", Client: "DomainsClient", Method: "ListDomains"},
+		{Package: "core", Client: "TagsClient", Method: "UpdateTag"},
+	}
+
+	gaps := findGaps(nil, allMethods, map[string]struct{}{}, map[string]exclusionEntry{}, map[string]struct{}{})
+
+	for _, m := range []string{"GetDomain", "ListDomains", "UpdateTag"} {
+		g, ok := findGapFor(gaps, m)
+		if !ok {
+			t.Errorf("read/update-only method %q must be reported as a gap (exhaustive report)", m)
+
+			continue
+		}
+
+		if g.Skipped != "" || g.Stale {
+			t.Errorf("uncovered method %q should be a plain gap, got skipped=%q stale=%v", m, g.Skipped, g.Stale)
+		}
+	}
+}
+
+func Test_receiverTypeName(t *testing.T) {
+	t.Parallel()
+
+	pkg := types.NewPackage("github.com/microsoft/fabric-sdk-go/fabric/core", "core")
+	client := types.NewNamed(
+		types.NewTypeName(token.NoPos, pkg, "WorkspacesClient", nil),
+		types.NewStruct(nil, nil),
+		nil,
+	)
+
+	tests := []struct {
+		name string
+		typ  types.Type
+		want string
+	}{
+		{"pointer receiver", types.NewPointer(client), "WorkspacesClient"},
+		{"value receiver", client, "WorkspacesClient"},
+		{"non-named type", types.Typ[types.Int], ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := receiverTypeName(tt.typ); got != tt.want {
+				t.Errorf("receiverTypeName(%s) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ng   nounGroup
+		want []string
+	}{
+		{
+			"explicit override wins",
+			nounGroup{Client: "CosmosDBDatabasesClient", Noun: "CosmosDBDatabase"},
+			[]string{"cosmos_db"},
+		},
+		{
+			"simple item noun (singular == plural stem)",
+			nounGroup{Client: "ItemsClient", Noun: "Lakehouse"},
+			[]string{"lakehouse", "item_lakehouse"},
+		},
+		{
+			"plural list noun yields singular + plural + prefixed",
+			nounGroup{Client: "WorkspacesClient", Noun: "InboundAzureResourceRules"},
+			[]string{
+				"inbound_azure_resource_rule",
+				"inbound_azure_resource_rules",
+				"workspace_inbound_azure_resource_rule",
+				"workspace_inbound_azure_resource_rules",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildCandidates(tt.ng)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("buildCandidates(%+v) = %v, want %v", tt.ng, got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_extractCoveredMethods_integration exercises the full go/packages
+// type-aware coverage detection against the real service packages. It is the
+// regression guard for the migration away from regex line-scanning: it proves
+// that a call made through a bare local variable (not r.client.X) is resolved.
+// It type-checks the whole dependency graph, so it is skipped under -short.
+// RequireSDK turns a missing module-root / SDK condition into a hard failure
+// when GAPCHECK_REQUIRE_SDK is set (as CI must set it), so the SDK-backed guard
+// tests cannot silently pass by skipping. Locally, without the env var, the
+// test still skips when the SDK is not resolvable. If err is non-nil this never
+// returns (it calls t.Fatalf or t.Skipf, both of which stop the test).
+func requireSDK(t *testing.T, err error, what string) {
+	t.Helper()
+
+	if err == nil {
+		return
+	}
+
+	if os.Getenv("GAPCHECK_REQUIRE_SDK") != "" {
+		t.Fatalf("GAPCHECK_REQUIRE_SDK is set but %s: %v", what, err)
+	}
+
+	t.Skipf("%s: %v", what, err)
+}
+
+func Test_extractCoveredMethods_integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping type-checking integration test in -short mode")
+	}
+
+	t.Parallel()
+
+	root, err := toolutil.ModuleRoot()
+	requireSDK(t, err, "find module root")
+
+	covered, err := extractCoveredMethods(root, toolutil.DefaultServicesDir)
+	if err != nil {
+		t.Fatalf("extractCoveredMethods: %v", err)
+	}
+
+	if len(covered) == 0 {
+		t.Fatal("extractCoveredMethods returned no covered methods")
+	}
+
+	// Every key must be "sdkPackage/ClientType/Method" so it matches
+	// sdkMethod.sdkMethodExclKey used by findGaps.
+	for key := range covered {
+		if strings.Count(key, "/") != 2 {
+			t.Errorf("covered key %q is not in pkg/Client/Method form", key)
+		}
+	}
+
+	// Methods that must resolve. UpdateDeploymentPipelineStage is called through
+	// a bare `client` variable — the exact shape the old regex scanner missed
+	// and the reason for the go/packages migration.
+	mustCover := []string{
+		"core/WorkspacesClient/CreateWorkspace",
+		"core/DeploymentPipelinesClient/UpdateDeploymentPipelineStage",
+	}
+	for _, key := range mustCover {
+		if _, ok := covered[key]; !ok {
+			t.Errorf("expected %q to be detected as covered, but it was not", key)
+		}
+	}
+}
+
+func Test_loadExclusions(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+
+		path := filepath.Join(t.TempDir(), "exclusions.yaml")
+
+		err := os.WriteFile(path, []byte(content), 0o600)
+		if err != nil {
+			t.Fatalf("writing temp exclusions file: %v", err)
+		}
+
+		return path
+	}
+
+	t.Run("valid entry with explicit method", func(t *testing.T) {
+		t.Parallel()
+
+		path := write(t, "exclusions:\n  - package: core\n    client: CatalogClient\n    method: GetCatalog\n    reason: read-only\n")
+
+		got, err := loadExclusions(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, ok := got["core/CatalogClient/GetCatalog"]; !ok {
+			t.Errorf("expected key core/CatalogClient/GetCatalog, got %v", got)
+		}
+	})
+
+	t.Run("empty method normalized to wildcard", func(t *testing.T) {
+		t.Parallel()
+
+		path := write(t, "exclusions:\n  - package: core\n    client: CatalogClient\n    reason: whole client excluded\n")
+
+		got, err := loadExclusions(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		entry, ok := got["core/CatalogClient/*"]
+		if !ok {
+			t.Fatalf("expected wildcard key core/CatalogClient/*, got %v", got)
+		}
+
+		if entry.Method != "*" {
+			t.Errorf("Method = %q, want %q", entry.Method, "*")
+		}
+	})
+
+	invalid := []struct {
+		name    string
+		content string
+	}{
+		{"missing reason", "exclusions:\n  - package: core\n    client: CatalogClient\n    method: GetCatalog\n"},
+		{"missing client", "exclusions:\n  - package: core\n    method: GetCatalog\n    reason: x\n"},
+		{"missing package", "exclusions:\n  - client: CatalogClient\n    method: GetCatalog\n    reason: x\n"},
+		{"malformed yaml (scalar where list expected)", "exclusions: not-a-list\n"},
+	}
+
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := write(t, tt.content)
+
+			_, err := loadExclusions(path)
+			if err == nil {
+				t.Errorf("expected error for %q, got nil", tt.name)
+			}
+		})
+	}
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loadExclusions(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+		if err == nil {
+			t.Error("expected error for nonexistent path, got nil")
+		}
+	})
+}
+
+// Test_nounTypeOverrides_notStale verifies that every key in nounTypeOverrides
+// corresponds to an actual noun extracted from the SDK. If the SDK renames or
+// removes a method, this test flags the stale override entry.
+func Test_nounTypeOverrides_notStale(t *testing.T) {
+	t.Parallel()
+
+	root, err := toolutil.ModuleRoot()
+	requireSDK(t, err, "find module root")
+
+	sdkDir, err := sdkFabricDir(root)
+	requireSDK(t, err, "resolve SDK")
+
+	// Collect all nouns from the SDK.
+	allNouns := collectAllSDKNouns(t, sdkDir)
+
+	for key := range nounTypeOverrides {
+		if _, ok := allNouns[key]; !ok {
+			t.Errorf("nounTypeOverrides key %q does not match any SDK noun — stale entry", key)
+		}
+	}
+}
+
+// Test_exclusionsFile_notStale verifies that every entry in exclusions.yaml
+// corresponds to an actual noun group in the SDK. Stale entries indicate the
+// SDK removed the operation.
+func Test_exclusionsFile_notStale(t *testing.T) {
+	t.Parallel()
+
+	root, err := toolutil.ModuleRoot()
+	requireSDK(t, err, "find module root")
+
+	sdkDir, err := sdkFabricDir(root)
+	requireSDK(t, err, "resolve SDK")
+
+	exclusionsPath := filepath.Join(root, "tools", "gapcheck", "exclusions.yaml")
+
+	exclusions, err := loadExclusions(exclusionsPath)
+	if err != nil {
+		t.Fatalf("loadExclusions: %v", err)
+	}
+
+	allMethods, err := extractAllMethods(sdkDir)
+	if err != nil {
+		t.Fatalf("extractAllMethods: %v", err)
+	}
+
+	// Build set of all method keys and client keys from the SDK.
+	allMethodKeys := map[string]struct{}{}
+	allClientKeys := map[string]struct{}{}
+
+	for _, m := range allMethods {
+		allMethodKeys[m.sdkMethodExclKey()] = struct{}{}
+		allClientKeys[m.Package+"/"+m.Client+"/*"] = struct{}{}
+	}
+
+	for key, entry := range exclusions {
+		if entry.Method == "*" {
+			// Wildcard: check that the client exists.
+			if _, ok := allClientKeys[key]; !ok {
+				t.Errorf("exclusions.yaml entry %q does not match any SDK client — stale entry", key)
+			}
+		} else {
+			// Exact method: check that it exists.
+			if _, ok := allMethodKeys[key]; !ok {
+				t.Errorf("exclusions.yaml entry %q does not match any SDK method — stale entry", key)
+			}
+		}
+	}
+}
+
+// collectAllSDKNouns extracts all noun names from SDK client methods across all packages.
+func collectAllSDKNouns(t *testing.T, sdkDir string) map[string]struct{} {
+	t.Helper()
+
+	nouns := map[string]struct{}{}
+
+	packages := []string{"core", "admin"}
+
+	// Add per-item packages.
+	entries, err := os.ReadDir(sdkDir)
+	if err != nil {
+		t.Fatalf("reading SDK dir: %v", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() && e.Name() != "core" && e.Name() != "admin" && e.Name() != "fake" {
+			packages = append(packages, e.Name())
+		}
+	}
+
+	for _, pkg := range packages {
+		pkgDir := filepath.Join(sdkDir, pkg)
+
+		files, readErr := os.ReadDir(pkgDir)
+		if readErr != nil {
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), "_client.go") || strings.Contains(f.Name(), "example") {
+				continue
+			}
+
+			data, fileErr := os.ReadFile(filepath.Join(pkgDir, f.Name()))
+			if fileErr != nil {
+				continue
+			}
+
+			for line := range strings.SplitSeq(string(data), "\n") {
+				_, method := parseClientMethod(line)
+				if method == "" {
+					continue
+				}
+
+				verb, noun := splitVerbNoun(method)
+				if verb == "Begin" {
+					// Strip Begin and re-parse the inner method.
+					_, noun = splitVerbNoun(noun)
+				}
+
+				if noun != "" {
+					nouns[noun] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return nouns
+}

--- a/tools/internal/toolutil/exclusions.go
+++ b/tools/internal/toolutil/exclusions.go
@@ -1,0 +1,51 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package toolutil
+
+import (
+	"fmt"
+	"os"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Exclusion suppresses a check for a single service package, together with the
+// reason the mismatch is intentional.
+type Exclusion struct {
+	Service string `json:"service" yaml:"service"`
+	Reason  string `json:"reason"  yaml:"reason"`
+}
+
+// ExclusionsFile is the top-level structure of an exclusions YAML file.
+type ExclusionsFile struct {
+	Exclusions []Exclusion `yaml:"exclusions"`
+}
+
+// LoadExclusions reads an exclusions YAML file and returns a map of service
+// package name to reason. Every entry must set both service and reason.
+func LoadExclusions(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading exclusions file %s: %w", path, err)
+	}
+
+	var ef ExclusionsFile
+
+	err = yaml.Unmarshal(data, &ef)
+	if err != nil {
+		return nil, fmt.Errorf("parsing exclusions file %s: %w", path, err)
+	}
+
+	result := make(map[string]string, len(ef.Exclusions))
+
+	for _, e := range ef.Exclusions {
+		if e.Service == "" || e.Reason == "" {
+			return nil, fmt.Errorf("exclusion entry missing required field (service, reason): %+v", e)
+		}
+
+		result[e.Service] = e.Reason
+	}
+
+	return result, nil
+}

--- a/tools/internal/toolutil/scan.go
+++ b/tools/internal/toolutil/scan.go
@@ -1,0 +1,379 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package toolutil
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// SDKCall identifies one distinct fabric-sdk-go function invoked by a service
+// package, along with the position of its declaration in the SDK source so the
+// caller can inspect the doc comment that documents the API.
+type SDKCall struct {
+	ID  string         // "pkgName.FuncName", e.g. "core.CreateShortcut"
+	Pos token.Position // position of the SDK function declaration
+}
+
+// CollectSDKCalls walks every call expression in the package and returns the
+// distinct fabric-sdk-go functions it invokes. The package must be loaded with
+// full type information and dependencies (see LoadServicePackages) so selector
+// expressions can be resolved to their declared objects (e.g. SDK client methods
+// reached through local variables, parameters, or embedding).
+func CollectSDKCalls(pkg *packages.Package) []SDKCall {
+	seen := map[string]struct{}{}
+
+	var calls []SDKCall
+
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			// Only x.Y(...) style calls; SDK funcs are always reached via a selector.
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			// Resolve the selector to its real declared object via the type checker.
+			fn, ok := pkg.TypesInfo.ObjectOf(sel.Sel).(*types.Func)
+			if !ok || fn.Pkg() == nil {
+				return true
+			}
+
+			if !strings.HasPrefix(fn.Pkg().Path(), SDKModulePath) {
+				return true
+			}
+
+			// Identify the callee as "pkgName.FuncName" and skip duplicates.
+			id := fn.Pkg().Name() + "." + fn.Name()
+			if _, dup := seen[id]; dup {
+				return true
+			}
+
+			seen[id] = struct{}{}
+			calls = append(calls, SDKCall{ID: id, Pos: pkg.Fset.Position(fn.Pos())})
+
+			return true
+		})
+	}
+
+	return calls
+}
+
+// ClientMethodDoc pairs an SDK client method name with the doc comment block
+// that immediately precedes its declaration.
+type ClientMethodDoc struct {
+	Name string
+	Doc  string
+}
+
+// DocCache lazily reads SDK source files and caches their lines, the doc comment
+// above declarations, and per-package CRUD method scans.
+type DocCache struct {
+	files map[string][]string
+	docs  map[string]string
+	crud  map[string][]ClientMethodDoc
+}
+
+// NewDocCache returns an empty DocCache ready for use.
+func NewDocCache() *DocCache {
+	return &DocCache{
+		files: map[string][]string{},
+		docs:  map[string]string{},
+		crud:  map[string][]ClientMethodDoc{},
+	}
+}
+
+// ReadFile returns the lines of path, reading and caching them on first access.
+func (d *DocCache) ReadFile(path string) ([]string, error) {
+	if lines, ok := d.files[path]; ok {
+		return lines, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	d.files[path] = lines
+
+	return lines, nil
+}
+
+// DocCommentAt returns the contiguous //-comment block directly above the
+// declaration at pos (joined by newlines), or "" if pos is unknown or the file
+// cannot be read. Results are cached per position.
+func (d *DocCache) DocCommentAt(pos token.Position) string {
+	if pos.Filename == "" || pos.Line <= 0 {
+		return ""
+	}
+
+	key := fmt.Sprintf("%s:%d", pos.Filename, pos.Line)
+	if v, ok := d.docs[key]; ok {
+		return v
+	}
+
+	doc := ""
+
+	lines, err := d.ReadFile(pos.Filename)
+	if err == nil {
+		doc = DocCommentAbove(lines, pos.Line)
+	}
+
+	d.docs[key] = doc
+
+	return doc
+}
+
+// ScanItemCRUD scans the *_client.go files in an SDK package directory and
+// returns the item's exported CRUD methods together with their doc comments,
+// sorted by method name. Results are cached per (directory, item).
+func (d *DocCache) ScanItemCRUD(pkgDir, item string) []ClientMethodDoc {
+	cacheKey := pkgDir + "\x00" + item
+	if v, ok := d.crud[cacheKey]; ok {
+		return v
+	}
+
+	var methods []ClientMethodDoc
+
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		d.crud[cacheKey] = nil
+
+		return nil
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_client.go") {
+			continue
+		}
+
+		lines, rErr := d.ReadFile(filepath.Join(pkgDir, e.Name()))
+		if rErr != nil {
+			continue
+		}
+
+		for i, line := range lines {
+			_, name := ParseClientMethod(line)
+			if name == "" || !IsItemCRUD(name, item) {
+				continue
+			}
+
+			// Line numbers passed to DocCommentAbove are 1-indexed.
+			methods = append(methods, ClientMethodDoc{Name: name, Doc: DocCommentAbove(lines, i+1)})
+		}
+	}
+
+	slices.SortFunc(methods, func(a, b ClientMethodDoc) int { return strings.Compare(a.Name, b.Name) })
+
+	d.crud[cacheKey] = methods
+
+	return methods
+}
+
+// DocCommentAbove returns the contiguous //-style comment block that sits
+// directly above the 1-indexed declLine, joined by newlines in source order.
+func DocCommentAbove(lines []string, declLine int) string {
+	// declLine is 1-indexed; the line directly above it is at slice index declLine-2.
+	end := declLine - 2
+	if end < 0 || end >= len(lines) || !strings.HasPrefix(strings.TrimSpace(lines[end]), "//") {
+		return ""
+	}
+
+	// Walk up to the top of the contiguous //-comment block.
+	start := end
+	for start-1 >= 0 && strings.HasPrefix(strings.TrimSpace(lines[start-1]), "//") {
+		start--
+	}
+
+	doc := make([]string, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		doc = append(doc, strings.TrimSpace(lines[i]))
+	}
+
+	return strings.Join(doc, "\n")
+}
+
+// ExtractItemTypeInfoBool returns the value of the named boolean field inside the
+// package's ItemTypeInfo composite literal, and whether the field was found with
+// a literal true/false value.
+func ExtractItemTypeInfoBool(pkg *packages.Package, field string) (bool, bool) { //nolint:revive // value + found
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				continue
+			}
+
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || !HasName(vs.Names, "ItemTypeInfo") {
+					continue
+				}
+
+				for _, val := range vs.Values {
+					lit, ok := val.(*ast.CompositeLit)
+					if !ok {
+						continue
+					}
+
+					if v, ok := extractBoolField(lit, field); ok {
+						return v, true
+					}
+				}
+			}
+		}
+	}
+
+	return false, false
+}
+
+func extractBoolField(lit *ast.CompositeLit, field string) (bool, bool) { //nolint:revive // value + found
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != field {
+			continue
+		}
+
+		ident, ok := kv.Value.(*ast.Ident)
+		if !ok || (ident.Name != "true" && ident.Name != "false") {
+			continue
+		}
+
+		return ident.Name == "true", true
+	}
+
+	return false, false
+}
+
+// FindFabricItemType locates the FabricItemType const (= fabcore.ItemType<Name>)
+// in the package and returns the SDK constant name plus a file in the fabcore
+// package (used to derive the SDK fabric/ directory).
+func FindFabricItemType(pkg *packages.Package) (string, string) { //nolint:revive // SDK const name + fabcore file path
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || !HasName(vs.Names, "FabricItemType") {
+					continue
+				}
+
+				for _, val := range vs.Values {
+					sel, ok := val.(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+
+					obj := pkg.TypesInfo.ObjectOf(sel.Sel)
+					if obj == nil || obj.Pkg() == nil {
+						continue
+					}
+
+					return obj.Name(), pkg.Fset.Position(obj.Pos()).Filename
+				}
+			}
+		}
+	}
+
+	return "", ""
+}
+
+// FabricRoot returns the fabric-sdk-go "fabric" directory given a file inside the
+// fabric/core package (e.g. .../fabric-sdk-go@v/fabric/core/x.go -> .../fabric).
+func FabricRoot(coreFile string) string {
+	dir := filepath.Dir(coreFile)
+	if filepath.Base(dir) != "core" {
+		return ""
+	}
+
+	return filepath.Dir(dir)
+}
+
+// SDKPackageDir resolves the package's FabricItemType constant to its dedicated
+// fabric-sdk-go package directory, returning the directory and the item name.
+// Overrides maps an item name to a non-default SDK package directory name when
+// the default lowercase derivation does not match.
+func SDKPackageDir(pkg *packages.Package, overrides map[string]string) (string, string, bool) { //nolint:revive // dir + item name + ok
+	constName, anyFile := FindFabricItemType(pkg)
+	if constName == "" || anyFile == "" {
+		return "", "", false
+	}
+
+	// ItemType constants are named ItemType<Name>; the SDK package is fabric/<name>.
+	item := strings.TrimPrefix(constName, "ItemType")
+	if item == constName || item == "" {
+		return "", "", false
+	}
+
+	fabricDir := FabricRoot(anyFile)
+	if fabricDir == "" {
+		return "", "", false
+	}
+
+	pkgName := strings.ToLower(item)
+	if override, has := overrides[item]; has {
+		pkgName = override
+	}
+
+	return filepath.Join(fabricDir, pkgName), item, true
+}
+
+// IsItemCRUD reports whether method is a CRUD operation on the item itself,
+// e.g. GetNotebook, BeginCreateNotebook, ListNotebooks, UpdateNotebook.
+func IsItemCRUD(method, item string) bool {
+	if !strings.Contains(strings.ToLower(method), strings.ToLower(item)) {
+		return false
+	}
+
+	for _, verb := range []string{"Get", "List", "Create", "Update", "Delete"} {
+		if strings.Contains(method, verb) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasName reports whether target appears among names.
+func HasName(names []*ast.Ident, target string) bool {
+	for _, n := range names {
+		if n.Name == target {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PkgName returns the package's name, falling back to the import-path base.
+func PkgName(pkg *packages.Package) string {
+	if pkg.Name != "" {
+		return pkg.Name
+	}
+
+	return filepath.Base(pkg.PkgPath)
+}

--- a/tools/internal/toolutil/toolutil.go
+++ b/tools/internal/toolutil/toolutil.go
@@ -1,0 +1,139 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package toolutil provides shared helpers for internal CLI tools
+// (previewcheck, gapcheck, etc.).
+package toolutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	// SDKModulePath is the Go module path of the Fabric SDK.
+	SDKModulePath = "github.com/microsoft/fabric-sdk-go"
+
+	// DefaultServicesDir is the default path to the services directory.
+	DefaultServicesDir = "internal/services"
+)
+
+// ModuleRoot walks up from the working directory to find the directory holding
+// go.mod.
+func ModuleRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s upward", dir)
+		}
+
+		dir = parent
+	}
+}
+
+// SortedKeys returns the sorted keys of a string set.
+func SortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}
+
+// Outf writes formatted output to stdout (for CLI tool results).
+func Outf(format string, a ...any) { fmt.Printf(format, a...) } //nolint:forbidigo
+
+// Errf writes formatted output to stderr (for CLI tool diagnostics).
+func Errf(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) }
+
+// LoadServicePackages type-checks every package under servicesDir (relative to
+// root) and returns them. It loads full type information and dependencies so
+// callers can resolve identifiers to their declared objects (e.g. fabric-sdk-go
+// client methods reached through local variables, parameters, or embedding).
+func LoadServicePackages(root, servicesDir string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
+			packages.NeedDeps,
+		Dir:   root,
+		Tests: false,
+	}
+
+	pattern := "./" + filepath.ToSlash(servicesDir) + "/..."
+
+	pkgs, err := packages.Load(cfg, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("loading packages under %q: %w", servicesDir, err)
+	}
+
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("no packages found under %q", servicesDir)
+	}
+
+	return pkgs, nil
+}
+
+// ParseClientMethod parses a Go source line declaring a method, of the form
+//
+//	func (recv *Type) Method(...)
+//	func (recv Type) Method(...)
+//
+// It returns the receiver's bare type name (with any leading '*' stripped) and
+// the method name, or empty strings if the line is not a method declaration or
+// the method is unexported. It is a lightweight line scanner for
+// machine-generated SDK client files, not a full Go parser.
+func ParseClientMethod(line string) (recvType, method string) { //nolint:nonamedreturns // named for clarity: receiver type + method name
+	const prefix = "func ("
+	if !strings.HasPrefix(line, prefix) {
+		return "", ""
+	}
+
+	// Isolate the receiver clause between the opening '(' and its closing ')'.
+	closeIdx := strings.IndexByte(line, ')')
+	if closeIdx <= len(prefix) {
+		return "", ""
+	}
+
+	// The receiver type is the last field, e.g. "client *WorkspacesClient".
+	recv := strings.Fields(line[len(prefix):closeIdx])
+	if len(recv) == 0 {
+		return "", ""
+	}
+
+	recvType = strings.TrimPrefix(recv[len(recv)-1], "*")
+	if recvType == "" {
+		return "", ""
+	}
+
+	// The method name follows the receiver clause, up to its parameter list.
+	rest := strings.TrimSpace(line[closeIdx+1:])
+
+	paren := strings.IndexByte(rest, '(')
+	if paren <= 0 {
+		return "", ""
+	}
+
+	method = rest[:paren]
+	if method[0] < 'A' || method[0] > 'Z' {
+		return "", "" // unexported, so not a public SDK method
+	}
+
+	return recvType, method
+}

--- a/tools/internal/toolutil/toolutil_test.go
+++ b/tools/internal/toolutil/toolutil_test.go
@@ -1,0 +1,44 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package toolutil_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
+)
+
+func TestParseClientMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		line     string
+		wantRecv string
+		wantMeth string
+	}{
+		{"pointer receiver", "func (client *WorkspacesClient) GetWorkspace(ctx context.Context) {", "WorkspacesClient", "GetWorkspace"},
+		{"value receiver", "func (c ItemsClient) ListItems() {", "ItemsClient", "ListItems"},
+		{"alternate receiver name", "func (d *PublishedClient) ListTags(id string) {", "PublishedClient", "ListTags"},
+		{"no space before paren", "func (c *T)Do(x int) {", "T", "Do"},
+		// Non-method / rejected shapes.
+		{"unexported method", "func (c *T) do() {", "", ""},
+		{"plain function", "func Helper() {", "", ""},
+		{"not a func", "type WorkspacesClient struct {", "", ""},
+		{"empty receiver", "func () Foo() {", "", ""},
+		{"no method params", "func (c *T) Field", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotRecv, gotMeth := toolutil.ParseClientMethod(tt.line)
+			if gotRecv != tt.wantRecv || gotMeth != tt.wantMeth {
+				t.Errorf("ParseClientMethod(%q) = (%q, %q), want (%q, %q)",
+					tt.line, gotRecv, gotMeth, tt.wantRecv, tt.wantMeth)
+			}
+		})
+	}
+}

--- a/tools/internal/toolutil/toolutil_test.go
+++ b/tools/internal/toolutil/toolutil_test.go
@@ -4,6 +4,9 @@
 package toolutil_test
 
 import (
+	"os"
+	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
@@ -41,4 +44,225 @@ func TestParseClientMethod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDocCommentAbove(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		lines    []string
+		declLine int
+		want     string
+	}{
+		{
+			"contiguous doc block",
+			[]string{
+				"// GetFoo retrieves a foo.",
+				"// This API is currently in preview.",
+				"func (client *FooClient) GetFoo() {}",
+			},
+			3,
+			"// GetFoo retrieves a foo.\n// This API is currently in preview.",
+		},
+		{
+			"blank line breaks the block",
+			[]string{
+				"// GetFoo retrieves a foo.",
+				"",
+				"func (client *FooClient) GetFoo() {}",
+			},
+			3,
+			"",
+		},
+		{
+			"non-comment line breaks the block",
+			[]string{
+				"import \"context\"",
+				"func (client *FooClient) GetFoo() {}",
+			},
+			2,
+			"",
+		},
+		{
+			"declaration on first line does not panic",
+			[]string{"func (client *FooClient) GetFoo() {}"},
+			1,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := toolutil.DocCommentAbove(tt.lines, tt.declLine); got != tt.want {
+				t.Errorf("DocCommentAbove(%d) = %q, want %q", tt.declLine, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsItemCRUD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		item   string
+		want   bool
+	}{
+		{"GetNotebook", "Notebook", true},
+		{"ListNotebooks", "Notebook", true},
+		{"BeginCreateNotebook", "Notebook", true},
+		{"UpdateNotebook", "Notebook", true},
+		{"DeleteNotebook", "Notebook", true},
+		// Item name matches but the verb is not a CRUD verb.
+		{"PublishNotebook", "Notebook", false},
+		// CRUD verb but the method is about a different entity.
+		{"GetWorkspace", "Notebook", false},
+		// Neither item nor CRUD verb.
+		{"ApplyTags", "Notebook", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+"/"+tt.item, func(t *testing.T) {
+			t.Parallel()
+
+			if got := toolutil.IsItemCRUD(tt.method, tt.item); got != tt.want {
+				t.Errorf("IsItemCRUD(%q, %q) = %v, want %v", tt.method, tt.item, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFabricRoot(t *testing.T) {
+	t.Parallel()
+
+	coreFile := filepath.Join("home", "user", "sdk", "fabric", "core", "zz_generated_models.go")
+	want := filepath.Join("home", "user", "sdk", "fabric")
+
+	if got := toolutil.FabricRoot(coreFile); got != want {
+		t.Errorf("FabricRoot(%q) = %q, want %q", coreFile, got, want)
+	}
+
+	notCore := filepath.Join("home", "user", "sdk", "fabric", "admin", "client.go")
+	if got := toolutil.FabricRoot(notCore); got != "" {
+		t.Errorf("FabricRoot(%q) = %q, want empty (parent dir is not core)", notCore, got)
+	}
+}
+
+func TestScanItemCRUD(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	content := "package notebook\n\n" +
+		"// GetNotebook gets a notebook.\n" +
+		"// This API is currently in preview.\n" +
+		"func (client *ItemsClient) GetNotebook(ctx context.Context) (Response, error) {}\n\n" +
+		"// ListNotebooks lists notebooks.\n" +
+		"func (client *ItemsClient) ListNotebooks(ctx context.Context) (Response, error) {}\n\n" +
+		"// ApplyLabel applies a label (not the item).\n" +
+		"func (client *ItemsClient) ApplyLabel(ctx context.Context) (Response, error) {}\n\n" +
+		"// getInternal is unexported and must be ignored.\n" +
+		"func (client *ItemsClient) getInternal() {}\n"
+
+	err := os.WriteFile(filepath.Join(dir, "items_client.go"), []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	methods := toolutil.NewDocCache().ScanItemCRUD(dir, "Notebook")
+
+	names := make([]string, 0, len(methods))
+	for _, m := range methods {
+		names = append(names, m.Name)
+	}
+
+	wantNames := []string{"GetNotebook", "ListNotebooks"}
+	if !slices.Equal(names, wantNames) {
+		t.Fatalf("CRUD methods = %v, want %v", names, wantNames)
+	}
+
+	if got := methods[0].Doc; got != "// GetNotebook gets a notebook.\n// This API is currently in preview." {
+		t.Errorf("GetNotebook doc = %q, want the preview marker block", got)
+	}
+
+	if got := methods[1].Doc; got != "// ListNotebooks lists notebooks." {
+		t.Errorf("ListNotebooks doc = %q, want its own doc line", got)
+	}
+}
+
+func TestLoadExclusions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions:\n  - service: foo\n    reason: GA, stale marker\n")
+
+		m, err := toolutil.LoadExclusions(path)
+		if err != nil {
+			t.Fatalf("LoadExclusions() error = %v", err)
+		}
+
+		if m["foo"] != "GA, stale marker" {
+			t.Errorf("m[foo] = %q, want the configured reason", m["foo"])
+		}
+	})
+
+	t.Run("missing service", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions:\n  - reason: no service\n")
+
+		_, err := toolutil.LoadExclusions(path)
+		if err == nil {
+			t.Error("LoadExclusions() error = nil, want error for missing service")
+		}
+	})
+
+	t.Run("missing reason", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions:\n  - service: foo\n")
+
+		_, err := toolutil.LoadExclusions(path)
+		if err == nil {
+			t.Error("LoadExclusions() error = nil, want error for missing reason")
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions: [::::\n")
+
+		_, err := toolutil.LoadExclusions(path)
+		if err == nil {
+			t.Error("LoadExclusions() error = nil, want parse error")
+		}
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := toolutil.LoadExclusions(filepath.Join(t.TempDir(), "nope.yaml"))
+		if err == nil {
+			t.Error("LoadExclusions() error = nil, want read error")
+		}
+	})
+}
+
+func writeExclusions(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "exclusions.yaml")
+
+	err := os.WriteFile(path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	return path
 }

--- a/tools/previewcheck/README.md
+++ b/tools/previewcheck/README.md
@@ -76,7 +76,4 @@ mismatch, e.g. the SDK removed the marker) is reported as **STALE** so it can be
 removed. Note that a service-level exclusion also suppresses *future* genuine
 preview APIs that item may start calling, so keep the list minimal and reasoned.
 
-## CI
-
-The `test-gaptools` job in `.github/workflows/test.yml` runs this tool's unit
-tests (via `task test:gaptools`) whenever `tools/**` changes.
+The tool's unit tests run via `task test:gaptools`.

--- a/tools/previewcheck/README.md
+++ b/tools/previewcheck/README.md
@@ -1,0 +1,82 @@
+# previewcheck
+
+`previewcheck` verifies that every Terraform resource/data source is correctly
+marked as **preview vs. GA**. It cross-checks each service package's declared
+preview status (`IsPreview` in `base.go`'s `ItemTypeInfo`) against the actual
+preview status of the [`fabric-sdk-go`](https://github.com/microsoft/fabric-sdk-go)
+APIs the package calls.
+
+## How it works
+
+A package should be `IsPreview = true` when **any** SDK client function it
+invokes is documented as preview. The SDK flags a preview API with one of these
+phrases in the doc comment directly above the function:
+
+- `is currently in preview`
+- `is part of a Preview release`
+
+`previewcheck` resolves each SDK call site to the exact SDK function (using the
+Go type checker, so import aliases and receivers resolve correctly), reads its
+doc comment, and compares the result against the declared `IsPreview` value.
+
+## Run it
+
+```sh
+go run ./tools/previewcheck                  # report findings, exit 1 if any
+go run ./tools/previewcheck -dir DIR         # scan a different services directory
+go run ./tools/previewcheck -exclusions PATH # use a specific exclusions file
+```
+
+Exit codes: `0` = all consistent, `1` = mismatch (or stale exclusion) found,
+`2` = error.
+
+## Reading the output
+
+Findings are split by confidence, because the SDK's preview annotations are
+incomplete (a missing marker does **not** guarantee an API is GA):
+
+- **UNDER-MARKED** (high confidence) — declared GA, but a called SDK API is
+  flagged preview. The item **should** be marked preview. Fix these.
+- **REVIEW** (low confidence) — declared preview, but no SDK preview marker was
+  found on any called API. *Possibly* demotable to GA, but confirm manually.
+- **EXCLUDED** — a failing item suppressed via `exclusions.yaml` (see below).
+- **STALE EXCLUSIONS** — an excluded item that is no longer a mismatch; remove
+  the entry. Stale entries also fail the run (exit `1`).
+- **UNDETERMINED** — no `fabric-sdk-go` calls found (e.g. generic `fabricitem`
+  resources whose CRUD runs through the shared abstraction). Informational.
+
+## Acting on a failure
+
+- **UNDER-MARKED** → set `IsPreview = true` on the item's `ItemTypeInfo` in its
+  `base.go`, **or** — if the item is genuinely GA and the SDK marker is stale —
+  exclude it (see below).
+- **REVIEW** → manually verify against Fabric docs; flip `IsPreview` to `false`
+  only if the API is truly GA.
+
+If an item calls an SDK package whose directory can't be derived from the item
+name automatically, add a mapping to `sdkPackageOverrides` in
+[`main.go`](./main.go).
+
+## Excluding GA items with stale SDK markers
+
+The SDK sometimes leaves a preview marker on an API that is actually GA. That
+makes an item show up as **UNDER-MARKED** even though keeping it GA is correct.
+List such items in [`exclusions.yaml`](./exclusions.yaml) with a reason:
+
+```yaml
+exclusions:
+  - service: tenantsetting
+    reason: GA; admin.UpdateTenantSetting still carries a stale SDK preview marker
+```
+
+`service` is the service package name (the value shown in the report). An
+excluded item moves to the **EXCLUDED** section instead of failing the run.
+Exclusion is deliberately narrow — a stale entry (the item is no longer a
+mismatch, e.g. the SDK removed the marker) is reported as **STALE** so it can be
+removed. Note that a service-level exclusion also suppresses *future* genuine
+preview APIs that item may start calling, so keep the list minimal and reasoned.
+
+## CI
+
+The `test-gaptools` job in `.github/workflows/test.yml` runs this tool's unit
+tests (via `task test:gaptools`) whenever `tools/**` changes.

--- a/tools/previewcheck/exclusions.yaml
+++ b/tools/previewcheck/exclusions.yaml
@@ -1,0 +1,13 @@
+# Exclusions for previewcheck — service packages whose preview status should
+# NOT be flagged, typically GA items whose called fabric-sdk-go APIs still carry
+# a stale preview marker in their doc comments.
+#
+# Format: service (the service package name) + reason.
+# When the SDK later removes the stale marker (so the service is no longer a
+# mismatch), previewcheck reports the entry as STALE so it can be removed.
+
+exclusions:
+  - service: tenantsetting
+    reason: GA; admin.UpdateTenantSetting still carries a stale SDK preview marker
+  - service: workspacempe
+    reason: GA; core.*WorkspaceManagedPrivateEndpoint APIs still carry stale SDK preview markers

--- a/tools/previewcheck/main.go
+++ b/tools/previewcheck/main.go
@@ -48,7 +48,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/packages"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
 )

--- a/tools/previewcheck/main.go
+++ b/tools/previewcheck/main.go
@@ -28,8 +28,12 @@
 //
 // Usage:
 //
-//	go run ./tools/previewcheck            # report findings, exit 1 if any
-//	go run ./tools/previewcheck -dir DIR   # scan a different services directory
+//	go run ./tools/previewcheck                  # report findings, exit 1 if any
+//	go run ./tools/previewcheck -dir DIR         # scan a different services directory
+//	go run ./tools/previewcheck -exclusions PATH # use a specific exclusions file
+//
+// A GA item whose called SDK API still carries a stale preview marker can be
+// suppressed by listing its service package in exclusions.yaml (see that file).
 package main
 
 import (
@@ -44,11 +48,9 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/packages"
-)
+	"gopkg.in/yaml.v3"
 
-const (
-	sdkModulePath   = "github.com/microsoft/fabric-sdk-go"
-	defaultServices = "internal/services"
+	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
 )
 
 // previewMarkers are the doc-comment phrases that flag an SDK API as preview
@@ -74,7 +76,50 @@ const (
 )
 
 // CLI flags.
-var dirFlag = flag.String("dir", defaultServices, "services directory to scan (relative to the module root)") //nolint:gochecknoglobals
+var (
+	dirFlag        = flag.String("dir", toolutil.DefaultServicesDir, "services directory to scan (relative to the module root)") //nolint:gochecknoglobals
+	exclusionsFlag = flag.String("exclusions", "", "path to exclusions YAML file (default: auto-detected)")                      //nolint:gochecknoglobals
+)
+
+// previewExclusion suppresses the preview check for a single service package,
+// typically a GA item whose called SDK API still carries a stale preview marker.
+type previewExclusion struct {
+	Service string `json:"service" yaml:"service"`
+	Reason  string `json:"reason"  yaml:"reason"`
+}
+
+// exclusionsFile is the top-level YAML structure of the exclusions file.
+type exclusionsFile struct {
+	Exclusions []previewExclusion `yaml:"exclusions"`
+}
+
+// loadExclusions reads the exclusions YAML file and returns a map of service
+// package name to reason.
+func loadExclusions(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading exclusions file %s: %w", path, err)
+	}
+
+	var ef exclusionsFile
+
+	err = yaml.Unmarshal(data, &ef)
+	if err != nil {
+		return nil, fmt.Errorf("parsing exclusions file %s: %w", path, err)
+	}
+
+	result := make(map[string]string, len(ef.Exclusions))
+
+	for _, e := range ef.Exclusions {
+		if e.Service == "" || e.Reason == "" {
+			return nil, fmt.Errorf("exclusion entry missing required field (service, reason): %+v", e)
+		}
+
+		result[e.Service] = e.Reason
+	}
+
+	return result, nil
+}
 
 func main() {
 	flag.Parse()
@@ -83,16 +128,28 @@ func main() {
 }
 
 func run() int {
-	root, err := moduleRoot()
+	root, err := toolutil.ModuleRoot()
 	if err != nil {
-		errf("error: %v\n", err)
+		toolutil.Errf("error: %v\n", err)
 
 		return exitError
 	}
 
-	pkgs, err := loadServicePackages(root, *dirFlag)
+	pkgs, err := toolutil.LoadServicePackages(root, *dirFlag)
 	if err != nil {
-		errf("error loading packages: %v\n", err)
+		toolutil.Errf("error loading packages: %v\n", err)
+
+		return exitError
+	}
+
+	exclusionsPath := *exclusionsFlag
+	if exclusionsPath == "" {
+		exclusionsPath = filepath.Join(root, "tools", "previewcheck", "exclusions.yaml")
+	}
+
+	exclusions, err := loadExclusions(exclusionsPath)
+	if err != nil {
+		toolutil.Errf("error loading exclusions: %v\n", err)
 
 		return exitError
 	}
@@ -104,7 +161,7 @@ func run() int {
 	for _, pkg := range pkgs {
 		if len(pkg.Errors) > 0 {
 			for _, e := range pkg.Errors {
-				errf("package %s: %v\n", pkg.PkgPath, e)
+				toolutil.Errf("package %s: %v\n", pkg.PkgPath, e)
 			}
 
 			return exitError
@@ -120,7 +177,7 @@ func run() int {
 
 	slices.SortFunc(results, func(a, b result) int { return strings.Compare(a.service, b.service) })
 
-	return report(results)
+	return report(results, exclusions)
 }
 
 // result captures the analysis outcome for a single service package.
@@ -139,63 +196,127 @@ func (r result) expected() bool { return len(r.previewAPIs) > 0 }
 // expected status can be trusted.
 func (r result) determinable() bool { return r.sdkCalls > 0 }
 
-func report(results []result) int {
-	b := categorize(results)
+func report(results []result, exclusions map[string]string) int {
+	b := categorize(results, exclusions)
 
 	for _, r := range b.undeclared {
-		outf("%-40s no ItemTypeInfo.IsPreview field found\n", r.service)
+		toolutil.Outf("%-40s no ItemTypeInfo.IsPreview field found\n", r.service)
 	}
 
 	printUnderMarked(b.underMarked)
 
 	printReview(b.review)
 
-	outf("\nScanned %d services: %d under-marked, %d to review, %d undetermined\n",
-		len(results), len(b.underMarked), len(b.review), b.undetermined)
+	printExcluded(b.excluded)
 
-	if len(b.underMarked) > 0 || len(b.review) > 0 {
+	printStaleExclusions(b.staleExcl)
+
+	toolutil.Outf("\nScanned %d services: %d under-marked, %d to review, %d undeclared, %d excluded, %d stale, %d undetermined\n",
+		len(results), len(b.underMarked), len(b.review), len(b.undeclared), len(b.excluded), len(b.staleExcl), b.undetermined)
+
+	if len(b.underMarked) > 0 || len(b.review) > 0 || len(b.undeclared) > 0 || len(b.staleExcl) > 0 {
 		return exitMismatch
 	}
 
 	return exitOK
 }
 
-// buckets groups categorized services by confidence level.
-type buckets struct {
-	underMarked  []result // declared GA but a called API is preview
-	review       []result // declared preview but no SDK marker found
-	undeclared   []result // no ItemTypeInfo.IsPreview field found
-	undetermined int      // no SDK calls, status not determinable
+// category is the preview-status classification of a single service.
+type category int
+
+const (
+	catConsistent   category = iota // declared status matches SDK usage
+	catUndetermined                 // no SDK calls, status not determinable
+	catUnderMarked                  // declared GA but a called API is preview
+	catReview                       // declared preview but no SDK marker found
+	catUndeclared                   // no ItemTypeInfo.IsPreview field found
+)
+
+// classify returns the preview-status category for a single result.
+func classify(r result) category {
+	if !r.hasDeclaration {
+		return catUndeclared
+	}
+
+	if !r.determinable() {
+		return catUndetermined
+	}
+
+	switch {
+	case !r.declared && r.expected():
+		return catUnderMarked
+	case r.declared && !r.expected():
+		return catReview
+	default:
+		return catConsistent
+	}
 }
 
-// categorize splits services into high-confidence under-marked, low-confidence
-// review, undeclared, and undetermined buckets.
-func categorize(results []result) buckets {
+// excludedResult is a failing service suppressed by the exclusions file.
+type excludedResult struct {
+	res    result
+	reason string
+}
+
+// buckets groups categorized services by confidence level.
+type buckets struct {
+	underMarked  []result         // declared GA but a called API is preview
+	review       []result         // declared preview but no SDK marker found
+	undeclared   []result         // no ItemTypeInfo.IsPreview field found
+	excluded     []excludedResult // failing but suppressed via exclusions.yaml
+	staleExcl    []string         // excluded services that no longer mismatch
+	undetermined int              // no SDK calls, status not determinable
+}
+
+// categorize splits services into under-marked, review, undeclared, excluded,
+// and undetermined groups, routing failing services listed in exclusions into
+// the excluded bucket and flagging exclusions that no longer apply as stale.
+func categorize(results []result, exclusions map[string]string) buckets {
 	var b buckets
 
+	used := make(map[string]struct{})
+
 	for _, r := range results {
-		if !r.hasDeclaration {
-			b.undeclared = append(b.undeclared, r)
-
-			continue
-		}
-
-		if !r.determinable() {
+		switch cat := classify(r); cat {
+		case catUndetermined:
 			b.undetermined++
-
-			continue
-		}
-
-		switch {
-		case !r.declared && r.expected():
-			b.underMarked = append(b.underMarked, r)
-		case r.declared && !r.expected():
-			b.review = append(b.review, r)
+		case catConsistent:
+			// declared status is correct; nothing to report.
 		default:
+			b.addFailing(r, cat, exclusions, used)
 		}
 	}
 
+	for svc := range exclusions {
+		if _, ok := used[svc]; !ok {
+			b.staleExcl = append(b.staleExcl, svc)
+		}
+	}
+
+	slices.Sort(b.staleExcl)
+
 	return b
+}
+
+// addFailing routes a failing result into the excluded bucket (if its service
+// is listed in exclusions) or its failing-category bucket.
+func (b *buckets) addFailing(r result, cat category, exclusions map[string]string, used map[string]struct{}) {
+	if reason, ok := exclusions[r.service]; ok {
+		b.excluded = append(b.excluded, excludedResult{res: r, reason: reason})
+		used[r.service] = struct{}{}
+
+		return
+	}
+
+	switch cat {
+	case catUnderMarked:
+		b.underMarked = append(b.underMarked, r)
+	case catReview:
+		b.review = append(b.review, r)
+	case catUndeclared:
+		b.undeclared = append(b.undeclared, r)
+	default:
+	}
 }
 
 func printUnderMarked(underMarked []result) {
@@ -203,10 +324,10 @@ func printUnderMarked(underMarked []result) {
 		return
 	}
 
-	outf("\nUNDER-MARKED — declared GA but the SDK marks a called API as preview (should be PREVIEW):\n")
+	toolutil.Outf("\nUNDER-MARKED — declared GA but the SDK marks a called API as preview (should be PREVIEW):\n")
 
 	for _, r := range underMarked {
-		outf("  ✗ %-38s\n", r.service)
+		toolutil.Outf("  ✗ %-38s\n", r.service)
 		printPreviewAPIs(r)
 	}
 }
@@ -216,10 +337,34 @@ func printReview(review []result) {
 		return
 	}
 
-	outf("\nREVIEW — declared PREVIEW but no SDK preview marker found (possibly GA, confirm manually):\n")
+	toolutil.Outf("\nREVIEW — declared PREVIEW but no SDK preview marker found (possibly GA, confirm manually):\n")
 
 	for _, r := range review {
-		outf("  ? %-38s\n", r.service)
+		toolutil.Outf("  ? %-38s\n", r.service)
+	}
+}
+
+func printExcluded(excluded []excludedResult) {
+	if len(excluded) == 0 {
+		return
+	}
+
+	toolutil.Outf("\nEXCLUDED — suppressed via exclusions.yaml (confirmed intentional):\n")
+
+	for _, e := range excluded {
+		toolutil.Outf("  - %-38s %s\n", e.res.service, e.reason)
+	}
+}
+
+func printStaleExclusions(stale []string) {
+	if len(stale) == 0 {
+		return
+	}
+
+	toolutil.Outf("\nSTALE EXCLUSIONS — no longer mismatched, remove from exclusions.yaml:\n")
+
+	for _, svc := range stale {
+		toolutil.Outf("  %s\n", svc)
 	}
 }
 
@@ -229,7 +374,7 @@ func printPreviewAPIs(r result) {
 	}
 
 	for _, api := range r.previewAPIs {
-		outf("    preview API: %s\n", api)
+		toolutil.Outf("    preview API: %s\n", api)
 	}
 }
 
@@ -241,9 +386,10 @@ func analyzePackage(pkg *packages.Package, dc *docCache) (result, bool) {
 	findIsPreview(pkg, &res)
 
 	previewSet := map[string]struct{}{}
+	seen := map[string]struct{}{}
 
 	for _, file := range pkg.Syntax {
-		collectSDKCalls(pkg, file, dc, &res, previewSet)
+		collectSDKCalls(pkg, file, dc, &res, previewSet, seen)
 	}
 
 	// Fallback: generic fabricitem resources make no direct SDK calls in-package.
@@ -253,7 +399,7 @@ func analyzePackage(pkg *packages.Package, dc *docCache) (result, bool) {
 		determineViaItemType(pkg, dc, &res, previewSet)
 	}
 
-	res.previewAPIs = sortedKeys(previewSet)
+	res.previewAPIs = toolutil.SortedKeys(previewSet)
 
 	// Skip packages that have neither a declaration nor any relevance.
 	if !res.hasDeclaration && res.sdkCalls == 0 {
@@ -417,10 +563,9 @@ func extractIsPreview(lit *ast.CompositeLit, res *result) bool {
 }
 
 // collectSDKCalls walks call expressions in a file, resolves each callee, and
-// records distinct fabric-sdk-go functions (flagging preview ones).
-func collectSDKCalls(pkg *packages.Package, file *ast.File, dc *docCache, res *result, previewSet map[string]struct{}) {
-	seen := map[string]struct{}{}
-
+// records distinct fabric-sdk-go functions (flagging preview ones). The seen set
+// is shared across the package's files so each callee is counted at most once.
+func collectSDKCalls(pkg *packages.Package, file *ast.File, dc *docCache, res *result, previewSet, seen map[string]struct{}) {
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -442,7 +587,7 @@ func collectSDKCalls(pkg *packages.Package, file *ast.File, dc *docCache, res *r
 			return true
 		}
 
-		if !strings.HasPrefix(fn.Pkg().Path(), sdkModulePath) {
+		if !strings.HasPrefix(fn.Pkg().Path(), toolutil.SDKModulePath) {
 			return true
 		}
 
@@ -486,16 +631,17 @@ func newDocCache() *docCache {
 // scanCRUD scans the *_client.go files in an SDK package directory and returns
 // the count of the item's exported CRUD methods plus the names of those flagged
 // preview. A non-zero count means the item status is determinable. Cached per
-// directory.
+// directory and item.
 func (d *docCache) scanCRUD(pkgDir, item string) (int, []string) {
-	if v, ok := d.methods[pkgDir]; ok {
-		return d.crud[pkgDir], v
+	cacheKey := pkgDir + "\x00" + item
+	if v, ok := d.methods[cacheKey]; ok {
+		return d.crud[cacheKey], v
 	}
 
 	entries, err := os.ReadDir(pkgDir)
 	if err != nil {
-		d.crud[pkgDir] = 0
-		d.methods[pkgDir] = nil
+		d.crud[cacheKey] = 0
+		d.methods[cacheKey] = nil
 
 		return 0, nil
 	}
@@ -523,8 +669,8 @@ func (d *docCache) scanCRUD(pkgDir, item string) (int, []string) {
 
 	slices.Sort(preview)
 
-	d.crud[pkgDir] = crud
-	d.methods[pkgDir] = preview
+	d.crud[cacheKey] = crud
+	d.methods[cacheKey] = preview
 
 	return crud, preview
 }
@@ -600,7 +746,7 @@ func scanItemMethods(lines []string, item string) (int, []string) {
 	)
 
 	for i, line := range lines {
-		name := exportedClientMethodName(line)
+		_, name := toolutil.ParseClientMethod(line)
 		if name == "" || !isItemCRUD(name, item) {
 			continue
 		}
@@ -619,7 +765,7 @@ func scanItemMethods(lines []string, item string) (int, []string) {
 // isItemCRUD reports whether method is a CRUD operation on the item itself,
 // e.g. GetNotebook, BeginCreateNotebook, ListNotebooks, UpdateNotebook.
 func isItemCRUD(method, item string) bool {
-	if !strings.Contains(method, item) {
+	if !strings.Contains(strings.ToLower(method), strings.ToLower(item)) {
 		return false
 	}
 
@@ -630,35 +776,6 @@ func isItemCRUD(method, item string) bool {
 	}
 
 	return false
-}
-
-// exportedClientMethodName extracts the exported method name from a declaration
-// like "func (client *ItemsClient) GetNotebook(...". Returns "" otherwise.
-func exportedClientMethodName(line string) string {
-	const prefix = "func (client *"
-
-	if !strings.HasPrefix(line, prefix) {
-		return ""
-	}
-
-	_, after, ok := strings.Cut(line, ") ")
-	if !ok {
-		return ""
-	}
-
-	rest := strings.TrimSpace(after)
-
-	paren := strings.IndexByte(rest, '(')
-	if paren <= 0 {
-		return ""
-	}
-
-	name := rest[:paren]
-	if name == "" || name[0] < 'A' || name[0] > 'Z' {
-		return ""
-	}
-
-	return name
 }
 
 func containsMarker(doc string) bool {
@@ -675,52 +792,6 @@ func containsMarker(doc string) bool {
 
 // loadServicePackages loads all packages under the services directory with full
 // type information.
-func loadServicePackages(root, servicesDir string) ([]*packages.Package, error) {
-	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
-			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
-			packages.NeedDeps,
-		Dir:   root,
-		Tests: false,
-	}
-
-	pattern := "./" + filepath.ToSlash(servicesDir) + "/..."
-
-	pkgs, err := packages.Load(cfg, pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(pkgs) == 0 {
-		return nil, fmt.Errorf("no packages found under %q", servicesDir)
-	}
-
-	return pkgs, nil
-}
-
-// moduleRoot walks up from the working directory to find the directory holding
-// go.mod.
-func moduleRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		_, err := os.Stat(filepath.Join(dir, "go.mod"))
-		if err == nil {
-			return dir, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("go.mod not found from %s upward", dir)
-		}
-
-		dir = parent
-	}
-}
-
 func pkgName(pkg *packages.Package) string {
 	if pkg.Name != "" {
 		return pkg.Name
@@ -738,18 +809,3 @@ func hasName(names []*ast.Ident, target string) bool {
 
 	return false
 }
-
-func sortedKeys(set map[string]struct{}) []string {
-	keys := make([]string, 0, len(set))
-	for k := range set {
-		keys = append(keys, k)
-	}
-
-	slices.Sort(keys)
-
-	return keys
-}
-
-func outf(format string, a ...any) { fmt.Printf(format, a...) } //nolint:forbidigo // CLI tool writes results to stdout
-
-func errf(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) } //nolint:revive // CLI tool writes diagnostics to stderr

--- a/tools/previewcheck/main.go
+++ b/tools/previewcheck/main.go
@@ -1,0 +1,755 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Command previewcheck audits every Terraform resource/data source service
+// package and verifies that its declared preview status (the IsPreview field in
+// base.go's ItemTypeInfo) matches the actual preview status of the Microsoft
+// Fabric Go SDK APIs that the package calls.
+//
+// An item must be marked as preview (IsPreview = true) when ANY of the
+// fabric-sdk-go client functions it invokes is documented as preview. The SDK
+// flags a preview API with one of the following phrases in the doc comment that
+// sits directly above the relevant client function:
+//
+//	"is currently in preview"
+//	"is part of a Preview release"
+//
+// If none of the called SDK functions are preview, the item is *likely* GA --
+// but note that the SDK's preview annotations are incomplete: a missing marker
+// does not guarantee the API is GA. Findings are therefore split by confidence:
+//
+//   - UNDER-MARKED (high confidence): declared GA but the SDK flags a called API
+//     as preview. The item should be preview.
+//   - REVIEW (low confidence): declared preview but no SDK preview marker was
+//     found on any called API. Possibly demotable to GA, but requires manual
+//     confirmation because SDK annotations are sparse.
+//   - UNDETERMINED: no fabric-sdk-go calls found in the package (e.g. generic
+//     fabricitem resources whose CRUD runs through the shared abstraction).
+//
+// Usage:
+//
+//	go run ./tools/previewcheck            # report findings, exit 1 if any
+//	go run ./tools/previewcheck -dir DIR   # scan a different services directory
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	sdkModulePath   = "github.com/microsoft/fabric-sdk-go"
+	defaultServices = "internal/services"
+)
+
+// previewMarkers are the doc-comment phrases that flag an SDK API as preview
+// (stored lowercase for case-insensitive matching).
+var previewMarkers = []string{ //nolint:gochecknoglobals
+	"is currently in preview",
+	"is part of a preview release",
+}
+
+// sdkPackageOverrides maps a FabricItemType item name to its dedicated
+// fabric-sdk-go package directory when the default lowercase derivation does not
+// match. Add entries here for any item whose SDK package cannot be resolved
+// automatically.
+var sdkPackageOverrides = map[string]string{ //nolint:gochecknoglobals
+	"Map": "maps",
+}
+
+// exit codes.
+const (
+	exitOK       = 0
+	exitMismatch = 1
+	exitError    = 2
+)
+
+// CLI flags.
+var dirFlag = flag.String("dir", defaultServices, "services directory to scan (relative to the module root)") //nolint:gochecknoglobals
+
+func main() {
+	flag.Parse()
+
+	os.Exit(run())
+}
+
+func run() int {
+	root, err := moduleRoot()
+	if err != nil {
+		errf("error: %v\n", err)
+
+		return exitError
+	}
+
+	pkgs, err := loadServicePackages(root, *dirFlag)
+	if err != nil {
+		errf("error loading packages: %v\n", err)
+
+		return exitError
+	}
+
+	dc := newDocCache()
+
+	results := make([]result, 0, len(pkgs))
+
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			for _, e := range pkg.Errors {
+				errf("package %s: %v\n", pkg.PkgPath, e)
+			}
+
+			return exitError
+		}
+
+		res, ok := analyzePackage(pkg, dc)
+		if !ok {
+			continue
+		}
+
+		results = append(results, res)
+	}
+
+	slices.SortFunc(results, func(a, b result) int { return strings.Compare(a.service, b.service) })
+
+	return report(results)
+}
+
+// result captures the analysis outcome for a single service package.
+type result struct {
+	service        string   // package name (e.g. "lakehouse")
+	declared       bool     // current IsPreview value
+	hasDeclaration bool     // ItemTypeInfo.IsPreview was found
+	sdkCalls       int      // number of distinct SDK funcs called
+	previewAPIs    []string // SDK funcs flagged as preview (pkg.Func)
+}
+
+// expected returns the IsPreview value implied by the SDK usage.
+func (r result) expected() bool { return len(r.previewAPIs) > 0 }
+
+// determinable is true when at least one SDK API call was found, so the
+// expected status can be trusted.
+func (r result) determinable() bool { return r.sdkCalls > 0 }
+
+func report(results []result) int {
+	b := categorize(results)
+
+	for _, r := range b.undeclared {
+		outf("%-40s no ItemTypeInfo.IsPreview field found\n", r.service)
+	}
+
+	printUnderMarked(b.underMarked)
+
+	printReview(b.review)
+
+	outf("\nScanned %d services: %d under-marked, %d to review, %d undetermined\n",
+		len(results), len(b.underMarked), len(b.review), b.undetermined)
+
+	if len(b.underMarked) > 0 || len(b.review) > 0 {
+		return exitMismatch
+	}
+
+	return exitOK
+}
+
+// buckets groups categorized services by confidence level.
+type buckets struct {
+	underMarked  []result // declared GA but a called API is preview
+	review       []result // declared preview but no SDK marker found
+	undeclared   []result // no ItemTypeInfo.IsPreview field found
+	undetermined int      // no SDK calls, status not determinable
+}
+
+// categorize splits services into high-confidence under-marked, low-confidence
+// review, undeclared, and undetermined buckets.
+func categorize(results []result) buckets {
+	var b buckets
+
+	for _, r := range results {
+		if !r.hasDeclaration {
+			b.undeclared = append(b.undeclared, r)
+
+			continue
+		}
+
+		if !r.determinable() {
+			b.undetermined++
+
+			continue
+		}
+
+		switch {
+		case !r.declared && r.expected():
+			b.underMarked = append(b.underMarked, r)
+		case r.declared && !r.expected():
+			b.review = append(b.review, r)
+		default:
+		}
+	}
+
+	return b
+}
+
+func printUnderMarked(underMarked []result) {
+	if len(underMarked) == 0 {
+		return
+	}
+
+	outf("\nUNDER-MARKED — declared GA but the SDK marks a called API as preview (should be PREVIEW):\n")
+
+	for _, r := range underMarked {
+		outf("  ✗ %-38s\n", r.service)
+		printPreviewAPIs(r)
+	}
+}
+
+func printReview(review []result) {
+	if len(review) == 0 {
+		return
+	}
+
+	outf("\nREVIEW — declared PREVIEW but no SDK preview marker found (possibly GA, confirm manually):\n")
+
+	for _, r := range review {
+		outf("  ? %-38s\n", r.service)
+	}
+}
+
+func printPreviewAPIs(r result) {
+	if len(r.previewAPIs) == 0 {
+		return
+	}
+
+	for _, api := range r.previewAPIs {
+		outf("    preview API: %s\n", api)
+	}
+}
+
+// analyzePackage inspects a service package: it locates ItemTypeInfo.IsPreview
+// and collects every fabric-sdk-go function it calls, flagging preview ones.
+func analyzePackage(pkg *packages.Package, dc *docCache) (result, bool) {
+	res := result{service: pkgName(pkg)}
+
+	findIsPreview(pkg, &res)
+
+	previewSet := map[string]struct{}{}
+
+	for _, file := range pkg.Syntax {
+		collectSDKCalls(pkg, file, dc, &res, previewSet)
+	}
+
+	// Fallback: generic fabricitem resources make no direct SDK calls in-package.
+	// Resolve their FabricItemType to the dedicated SDK package and scan its
+	// exported client methods for preview markers.
+	if res.sdkCalls == 0 {
+		determineViaItemType(pkg, dc, &res, previewSet)
+	}
+
+	res.previewAPIs = sortedKeys(previewSet)
+
+	// Skip packages that have neither a declaration nor any relevance.
+	if !res.hasDeclaration && res.sdkCalls == 0 {
+		return res, false
+	}
+
+	return res, true
+}
+
+// determineViaItemType resolves the FabricItemType constant to its dedicated
+// fabric-sdk-go package and scans that package's exported client methods for
+// preview markers, closing the gap for generic fabricitem resources.
+func determineViaItemType(pkg *packages.Package, dc *docCache, res *result, previewSet map[string]struct{}) {
+	pkgDir, item, ok := sdkPackageDir(pkg)
+	if !ok {
+		return
+	}
+
+	crud, methods := dc.scanCRUD(pkgDir, item)
+	if crud == 0 {
+		return
+	}
+
+	res.sdkCalls += crud
+
+	for _, m := range methods {
+		previewSet[strings.ToLower(item)+"."+m] = struct{}{}
+	}
+}
+
+// sdkPackageDir resolves a package's FabricItemType constant to its dedicated
+// fabric-sdk-go package directory, returning the directory and the item name.
+func sdkPackageDir(pkg *packages.Package) (string, string, bool) { //nolint:revive // dir + item name + ok
+	constName, anyFile := findFabricItemType(pkg)
+	if constName == "" || anyFile == "" {
+		return "", "", false
+	}
+
+	// ItemType constants are named ItemType<Name>; the SDK package is fabric/<name>.
+	item := strings.TrimPrefix(constName, "ItemType")
+	if item == constName || item == "" {
+		return "", "", false
+	}
+
+	fabricDir := fabricRoot(anyFile)
+	if fabricDir == "" {
+		return "", "", false
+	}
+
+	pkgName := strings.ToLower(item)
+	if override, ok := sdkPackageOverrides[item]; ok {
+		pkgName = override
+	}
+
+	return filepath.Join(fabricDir, pkgName), item, true
+}
+
+// findFabricItemType locates the FabricItemType const (= fabcore.ItemType<Name>)
+// and returns the SDK constant name plus a file in the fabcore package (used to
+// derive the SDK fabric/ directory).
+func findFabricItemType(pkg *packages.Package) (string, string) { //nolint:revive // two strings: SDK const name and fabcore file path
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || !hasName(vs.Names, "FabricItemType") {
+					continue
+				}
+
+				for _, val := range vs.Values {
+					sel, ok := val.(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+
+					obj := pkg.TypesInfo.ObjectOf(sel.Sel)
+					if obj == nil || obj.Pkg() == nil {
+						continue
+					}
+
+					return obj.Name(), pkg.Fset.Position(obj.Pos()).Filename
+				}
+			}
+		}
+	}
+
+	return "", ""
+}
+
+// fabricRoot returns the fabric-sdk-go "fabric" directory given a file inside
+// the fabric/core package (e.g. .../fabric-sdk-go@v/fabric/core/x.go -> .../fabric).
+func fabricRoot(coreFile string) string {
+	dir := filepath.Dir(coreFile)
+	if filepath.Base(dir) != "core" {
+		return ""
+	}
+
+	return filepath.Dir(dir)
+}
+
+// findIsPreview locates the IsPreview field inside the ItemTypeInfo composite
+// literal and records its value.
+func findIsPreview(pkg *packages.Package, res *result) {
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				continue
+			}
+
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || !hasName(vs.Names, "ItemTypeInfo") {
+					continue
+				}
+
+				for _, val := range vs.Values {
+					lit, ok := val.(*ast.CompositeLit)
+					if !ok {
+						continue
+					}
+
+					if extractIsPreview(lit, res) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+func extractIsPreview(lit *ast.CompositeLit, res *result) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "IsPreview" {
+			continue
+		}
+
+		ident, ok := kv.Value.(*ast.Ident)
+		if !ok || (ident.Name != "true" && ident.Name != "false") {
+			continue
+		}
+
+		res.hasDeclaration = true
+		res.declared = ident.Name == "true"
+
+		return true
+	}
+
+	return false
+}
+
+// collectSDKCalls walks call expressions in a file, resolves each callee, and
+// records distinct fabric-sdk-go functions (flagging preview ones).
+func collectSDKCalls(pkg *packages.Package, file *ast.File, dc *docCache, res *result, previewSet map[string]struct{}) {
+	seen := map[string]struct{}{}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		// Only x.Y(...) style calls; SDK funcs are always reached via a selector.
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		// Resolve the selector to its real declared object via the type checker
+		// (relies on NeedTypes/NeedTypesInfo/NeedDeps when loading packages).
+		obj := pkg.TypesInfo.ObjectOf(sel.Sel)
+
+		fn, ok := obj.(*types.Func)
+		if !ok || fn.Pkg() == nil {
+			return true
+		}
+
+		if !strings.HasPrefix(fn.Pkg().Path(), sdkModulePath) {
+			return true
+		}
+
+		// Identify the callee as "pkgName.FuncName" and skip duplicates.
+		id := fn.Pkg().Name() + "." + fn.Name()
+		if _, dup := seen[id]; dup {
+			return true
+		}
+
+		seen[id] = struct{}{}
+		res.sdkCalls++
+
+		// fn.Pos() points at the SDK declaration; check its doc comment for a
+		// preview marker and record the func if it is preview.
+		if dc.isPreview(pkg.Fset.Position(fn.Pos())) {
+			previewSet[id] = struct{}{}
+		}
+
+		return true
+	})
+}
+
+// docCache reads SDK source files lazily and caches the preview status of the
+// doc comment directly above a declaration position.
+type docCache struct {
+	files   map[string][]string
+	results map[string]bool
+	methods map[string][]string
+	crud    map[string]int
+}
+
+func newDocCache() *docCache {
+	return &docCache{
+		files:   map[string][]string{},
+		results: map[string]bool{},
+		methods: map[string][]string{},
+		crud:    map[string]int{},
+	}
+}
+
+// scanCRUD scans the *_client.go files in an SDK package directory and returns
+// the count of the item's exported CRUD methods plus the names of those flagged
+// preview. A non-zero count means the item status is determinable. Cached per
+// directory.
+func (d *docCache) scanCRUD(pkgDir, item string) (int, []string) {
+	if v, ok := d.methods[pkgDir]; ok {
+		return d.crud[pkgDir], v
+	}
+
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		d.crud[pkgDir] = 0
+		d.methods[pkgDir] = nil
+
+		return 0, nil
+	}
+
+	var (
+		crud    int
+		preview []string
+	)
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_client.go") {
+			continue
+		}
+
+		lines, rErr := d.readFile(filepath.Join(pkgDir, e.Name()))
+		if rErr != nil {
+			continue
+		}
+
+		c, p := scanItemMethods(lines, item)
+		crud += c
+
+		preview = append(preview, p...)
+	}
+
+	slices.Sort(preview)
+
+	d.crud[pkgDir] = crud
+	d.methods[pkgDir] = preview
+
+	return crud, preview
+}
+
+// isPreview reports whether the doc comment immediately above the declaration at
+// pos contains a preview marker.
+func (d *docCache) isPreview(pos token.Position) bool {
+	if pos.Filename == "" || pos.Line <= 0 {
+		return false
+	}
+
+	key := fmt.Sprintf("%s:%d", pos.Filename, pos.Line)
+	if v, ok := d.results[key]; ok {
+		return v
+	}
+
+	lines, err := d.readFile(pos.Filename)
+	if err != nil {
+		d.results[key] = false
+
+		return false
+	}
+
+	doc := docCommentAbove(lines, pos.Line)
+	preview := containsMarker(doc)
+	d.results[key] = preview
+
+	return preview
+}
+
+func (d *docCache) readFile(path string) ([]string, error) {
+	if lines, ok := d.files[path]; ok {
+		return lines, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	d.files[path] = lines
+
+	return lines, nil
+}
+
+// docCommentAbove returns the contiguous //-style comment block that sits
+// directly above the 1-indexed declLine.
+func docCommentAbove(lines []string, declLine int) string {
+	// declLine is 1-indexed; the line above it is at slice index declLine-2.
+	var doc []string
+
+	for i := declLine - 2; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "//") {
+			doc = append(doc, trimmed)
+
+			continue
+		}
+
+		break
+	}
+
+	return strings.Join(doc, "\n")
+}
+
+// scanItemMethods returns the count of the item's CRUD client methods in the
+// file and the names of those whose preceding doc comment is marked preview.
+func scanItemMethods(lines []string, item string) (int, []string) {
+	var (
+		crud    int
+		preview []string
+	)
+
+	for i, line := range lines {
+		name := exportedClientMethodName(line)
+		if name == "" || !isItemCRUD(name, item) {
+			continue
+		}
+
+		crud++
+
+		// Line numbers passed to docCommentAbove are 1-indexed.
+		if containsMarker(docCommentAbove(lines, i+1)) {
+			preview = append(preview, name)
+		}
+	}
+
+	return crud, preview
+}
+
+// isItemCRUD reports whether method is a CRUD operation on the item itself,
+// e.g. GetNotebook, BeginCreateNotebook, ListNotebooks, UpdateNotebook.
+func isItemCRUD(method, item string) bool {
+	if !strings.Contains(method, item) {
+		return false
+	}
+
+	for _, verb := range []string{"Get", "List", "Create", "Update", "Delete"} {
+		if strings.Contains(method, verb) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// exportedClientMethodName extracts the exported method name from a declaration
+// like "func (client *ItemsClient) GetNotebook(...". Returns "" otherwise.
+func exportedClientMethodName(line string) string {
+	const prefix = "func (client *"
+
+	if !strings.HasPrefix(line, prefix) {
+		return ""
+	}
+
+	_, after, ok := strings.Cut(line, ") ")
+	if !ok {
+		return ""
+	}
+
+	rest := strings.TrimSpace(after)
+
+	paren := strings.IndexByte(rest, '(')
+	if paren <= 0 {
+		return ""
+	}
+
+	name := rest[:paren]
+	if name == "" || name[0] < 'A' || name[0] > 'Z' {
+		return ""
+	}
+
+	return name
+}
+
+func containsMarker(doc string) bool {
+	lower := strings.ToLower(doc)
+
+	for _, marker := range previewMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// loadServicePackages loads all packages under the services directory with full
+// type information.
+func loadServicePackages(root, servicesDir string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
+			packages.NeedDeps,
+		Dir:   root,
+		Tests: false,
+	}
+
+	pattern := "./" + filepath.ToSlash(servicesDir) + "/..."
+
+	pkgs, err := packages.Load(cfg, pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("no packages found under %q", servicesDir)
+	}
+
+	return pkgs, nil
+}
+
+// moduleRoot walks up from the working directory to find the directory holding
+// go.mod.
+func moduleRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		_, err := os.Stat(filepath.Join(dir, "go.mod"))
+		if err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s upward", dir)
+		}
+
+		dir = parent
+	}
+}
+
+func pkgName(pkg *packages.Package) string {
+	if pkg.Name != "" {
+		return pkg.Name
+	}
+
+	return filepath.Base(pkg.PkgPath)
+}
+
+func hasName(names []*ast.Ident, target string) bool {
+	for _, n := range names {
+		if n.Name == target {
+			return true
+		}
+	}
+
+	return false
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}
+
+func outf(format string, a ...any) { fmt.Printf(format, a...) } //nolint:forbidigo // CLI tool writes results to stdout
+
+func errf(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) } //nolint:revive // CLI tool writes diagnostics to stderr

--- a/tools/previewcheck/main.go
+++ b/tools/previewcheck/main.go
@@ -38,17 +38,12 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"go/ast"
-	"go/token"
-	"go/types"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
-	"go.yaml.in/yaml/v3"
 
 	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
 )
@@ -81,46 +76,6 @@ var (
 	exclusionsFlag = flag.String("exclusions", "", "path to exclusions YAML file (default: auto-detected)")                      //nolint:gochecknoglobals
 )
 
-// previewExclusion suppresses the preview check for a single service package,
-// typically a GA item whose called SDK API still carries a stale preview marker.
-type previewExclusion struct {
-	Service string `json:"service" yaml:"service"`
-	Reason  string `json:"reason"  yaml:"reason"`
-}
-
-// exclusionsFile is the top-level YAML structure of the exclusions file.
-type exclusionsFile struct {
-	Exclusions []previewExclusion `yaml:"exclusions"`
-}
-
-// loadExclusions reads the exclusions YAML file and returns a map of service
-// package name to reason.
-func loadExclusions(path string) (map[string]string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading exclusions file %s: %w", path, err)
-	}
-
-	var ef exclusionsFile
-
-	err = yaml.Unmarshal(data, &ef)
-	if err != nil {
-		return nil, fmt.Errorf("parsing exclusions file %s: %w", path, err)
-	}
-
-	result := make(map[string]string, len(ef.Exclusions))
-
-	for _, e := range ef.Exclusions {
-		if e.Service == "" || e.Reason == "" {
-			return nil, fmt.Errorf("exclusion entry missing required field (service, reason): %+v", e)
-		}
-
-		result[e.Service] = e.Reason
-	}
-
-	return result, nil
-}
-
 func main() {
 	flag.Parse()
 
@@ -147,14 +102,14 @@ func run() int {
 		exclusionsPath = filepath.Join(root, "tools", "previewcheck", "exclusions.yaml")
 	}
 
-	exclusions, err := loadExclusions(exclusionsPath)
+	exclusions, err := toolutil.LoadExclusions(exclusionsPath)
 	if err != nil {
 		toolutil.Errf("error loading exclusions: %v\n", err)
 
 		return exitError
 	}
 
-	dc := newDocCache()
+	dc := toolutil.NewDocCache()
 
 	results := make([]result, 0, len(pkgs))
 
@@ -380,16 +335,22 @@ func printPreviewAPIs(r result) {
 
 // analyzePackage inspects a service package: it locates ItemTypeInfo.IsPreview
 // and collects every fabric-sdk-go function it calls, flagging preview ones.
-func analyzePackage(pkg *packages.Package, dc *docCache) (result, bool) {
-	res := result{service: pkgName(pkg)}
+func analyzePackage(pkg *packages.Package, dc *toolutil.DocCache) (result, bool) {
+	res := result{service: toolutil.PkgName(pkg)}
 
-	findIsPreview(pkg, &res)
+	if v, ok := toolutil.ExtractItemTypeInfoBool(pkg, "IsPreview"); ok {
+		res.hasDeclaration = true
+		res.declared = v
+	}
 
 	previewSet := map[string]struct{}{}
-	seen := map[string]struct{}{}
 
-	for _, file := range pkg.Syntax {
-		collectSDKCalls(pkg, file, dc, &res, previewSet, seen)
+	for _, call := range toolutil.CollectSDKCalls(pkg) {
+		res.sdkCalls++
+
+		if containsMarker(dc.DocCommentAt(call.Pos)) {
+			previewSet[call.ID] = struct{}{}
+		}
 	}
 
 	// Fallback: generic fabricitem resources make no direct SDK calls in-package.
@@ -412,370 +373,24 @@ func analyzePackage(pkg *packages.Package, dc *docCache) (result, bool) {
 // determineViaItemType resolves the FabricItemType constant to its dedicated
 // fabric-sdk-go package and scans that package's exported client methods for
 // preview markers, closing the gap for generic fabricitem resources.
-func determineViaItemType(pkg *packages.Package, dc *docCache, res *result, previewSet map[string]struct{}) {
-	pkgDir, item, ok := sdkPackageDir(pkg)
+func determineViaItemType(pkg *packages.Package, dc *toolutil.DocCache, res *result, previewSet map[string]struct{}) {
+	pkgDir, item, ok := toolutil.SDKPackageDir(pkg, sdkPackageOverrides)
 	if !ok {
 		return
 	}
 
-	crud, methods := dc.scanCRUD(pkgDir, item)
-	if crud == 0 {
+	methods := dc.ScanItemCRUD(pkgDir, item)
+	if len(methods) == 0 {
 		return
 	}
 
-	res.sdkCalls += crud
+	res.sdkCalls += len(methods)
 
 	for _, m := range methods {
-		previewSet[strings.ToLower(item)+"."+m] = struct{}{}
-	}
-}
-
-// sdkPackageDir resolves a package's FabricItemType constant to its dedicated
-// fabric-sdk-go package directory, returning the directory and the item name.
-func sdkPackageDir(pkg *packages.Package) (string, string, bool) { //nolint:revive // dir + item name + ok
-	constName, anyFile := findFabricItemType(pkg)
-	if constName == "" || anyFile == "" {
-		return "", "", false
-	}
-
-	// ItemType constants are named ItemType<Name>; the SDK package is fabric/<name>.
-	item := strings.TrimPrefix(constName, "ItemType")
-	if item == constName || item == "" {
-		return "", "", false
-	}
-
-	fabricDir := fabricRoot(anyFile)
-	if fabricDir == "" {
-		return "", "", false
-	}
-
-	pkgName := strings.ToLower(item)
-	if override, ok := sdkPackageOverrides[item]; ok {
-		pkgName = override
-	}
-
-	return filepath.Join(fabricDir, pkgName), item, true
-}
-
-// findFabricItemType locates the FabricItemType const (= fabcore.ItemType<Name>)
-// and returns the SDK constant name plus a file in the fabcore package (used to
-// derive the SDK fabric/ directory).
-func findFabricItemType(pkg *packages.Package) (string, string) { //nolint:revive // two strings: SDK const name and fabcore file path
-	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok || gen.Tok != token.CONST {
-				continue
-			}
-
-			for _, spec := range gen.Specs {
-				vs, ok := spec.(*ast.ValueSpec)
-				if !ok || !hasName(vs.Names, "FabricItemType") {
-					continue
-				}
-
-				for _, val := range vs.Values {
-					sel, ok := val.(*ast.SelectorExpr)
-					if !ok {
-						continue
-					}
-
-					obj := pkg.TypesInfo.ObjectOf(sel.Sel)
-					if obj == nil || obj.Pkg() == nil {
-						continue
-					}
-
-					return obj.Name(), pkg.Fset.Position(obj.Pos()).Filename
-				}
-			}
+		if containsMarker(m.Doc) {
+			previewSet[strings.ToLower(item)+"."+m.Name] = struct{}{}
 		}
 	}
-
-	return "", ""
-}
-
-// fabricRoot returns the fabric-sdk-go "fabric" directory given a file inside
-// the fabric/core package (e.g. .../fabric-sdk-go@v/fabric/core/x.go -> .../fabric).
-func fabricRoot(coreFile string) string {
-	dir := filepath.Dir(coreFile)
-	if filepath.Base(dir) != "core" {
-		return ""
-	}
-
-	return filepath.Dir(dir)
-}
-
-// findIsPreview locates the IsPreview field inside the ItemTypeInfo composite
-// literal and records its value.
-func findIsPreview(pkg *packages.Package, res *result) {
-	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok || gen.Tok != token.VAR {
-				continue
-			}
-
-			for _, spec := range gen.Specs {
-				vs, ok := spec.(*ast.ValueSpec)
-				if !ok || !hasName(vs.Names, "ItemTypeInfo") {
-					continue
-				}
-
-				for _, val := range vs.Values {
-					lit, ok := val.(*ast.CompositeLit)
-					if !ok {
-						continue
-					}
-
-					if extractIsPreview(lit, res) {
-						return
-					}
-				}
-			}
-		}
-	}
-}
-
-func extractIsPreview(lit *ast.CompositeLit, res *result) bool {
-	for _, elt := range lit.Elts {
-		kv, ok := elt.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-
-		key, ok := kv.Key.(*ast.Ident)
-		if !ok || key.Name != "IsPreview" {
-			continue
-		}
-
-		ident, ok := kv.Value.(*ast.Ident)
-		if !ok || (ident.Name != "true" && ident.Name != "false") {
-			continue
-		}
-
-		res.hasDeclaration = true
-		res.declared = ident.Name == "true"
-
-		return true
-	}
-
-	return false
-}
-
-// collectSDKCalls walks call expressions in a file, resolves each callee, and
-// records distinct fabric-sdk-go functions (flagging preview ones). The seen set
-// is shared across the package's files so each callee is counted at most once.
-func collectSDKCalls(pkg *packages.Package, file *ast.File, dc *docCache, res *result, previewSet, seen map[string]struct{}) {
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-
-		// Only x.Y(...) style calls; SDK funcs are always reached via a selector.
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-
-		// Resolve the selector to its real declared object via the type checker
-		// (relies on NeedTypes/NeedTypesInfo/NeedDeps when loading packages).
-		obj := pkg.TypesInfo.ObjectOf(sel.Sel)
-
-		fn, ok := obj.(*types.Func)
-		if !ok || fn.Pkg() == nil {
-			return true
-		}
-
-		if !strings.HasPrefix(fn.Pkg().Path(), toolutil.SDKModulePath) {
-			return true
-		}
-
-		// Identify the callee as "pkgName.FuncName" and skip duplicates.
-		id := fn.Pkg().Name() + "." + fn.Name()
-		if _, dup := seen[id]; dup {
-			return true
-		}
-
-		seen[id] = struct{}{}
-		res.sdkCalls++
-
-		// fn.Pos() points at the SDK declaration; check its doc comment for a
-		// preview marker and record the func if it is preview.
-		if dc.isPreview(pkg.Fset.Position(fn.Pos())) {
-			previewSet[id] = struct{}{}
-		}
-
-		return true
-	})
-}
-
-// docCache reads SDK source files lazily and caches the preview status of the
-// doc comment directly above a declaration position.
-type docCache struct {
-	files   map[string][]string
-	results map[string]bool
-	methods map[string][]string
-	crud    map[string]int
-}
-
-func newDocCache() *docCache {
-	return &docCache{
-		files:   map[string][]string{},
-		results: map[string]bool{},
-		methods: map[string][]string{},
-		crud:    map[string]int{},
-	}
-}
-
-// scanCRUD scans the *_client.go files in an SDK package directory and returns
-// the count of the item's exported CRUD methods plus the names of those flagged
-// preview. A non-zero count means the item status is determinable. Cached per
-// directory and item.
-func (d *docCache) scanCRUD(pkgDir, item string) (int, []string) {
-	cacheKey := pkgDir + "\x00" + item
-	if v, ok := d.methods[cacheKey]; ok {
-		return d.crud[cacheKey], v
-	}
-
-	entries, err := os.ReadDir(pkgDir)
-	if err != nil {
-		d.crud[cacheKey] = 0
-		d.methods[cacheKey] = nil
-
-		return 0, nil
-	}
-
-	var (
-		crud    int
-		preview []string
-	)
-
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), "_client.go") {
-			continue
-		}
-
-		lines, rErr := d.readFile(filepath.Join(pkgDir, e.Name()))
-		if rErr != nil {
-			continue
-		}
-
-		c, p := scanItemMethods(lines, item)
-		crud += c
-
-		preview = append(preview, p...)
-	}
-
-	slices.Sort(preview)
-
-	d.crud[cacheKey] = crud
-	d.methods[cacheKey] = preview
-
-	return crud, preview
-}
-
-// isPreview reports whether the doc comment immediately above the declaration at
-// pos contains a preview marker.
-func (d *docCache) isPreview(pos token.Position) bool {
-	if pos.Filename == "" || pos.Line <= 0 {
-		return false
-	}
-
-	key := fmt.Sprintf("%s:%d", pos.Filename, pos.Line)
-	if v, ok := d.results[key]; ok {
-		return v
-	}
-
-	lines, err := d.readFile(pos.Filename)
-	if err != nil {
-		d.results[key] = false
-
-		return false
-	}
-
-	doc := docCommentAbove(lines, pos.Line)
-	preview := containsMarker(doc)
-	d.results[key] = preview
-
-	return preview
-}
-
-func (d *docCache) readFile(path string) ([]string, error) {
-	if lines, ok := d.files[path]; ok {
-		return lines, nil
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	lines := strings.Split(string(data), "\n")
-	d.files[path] = lines
-
-	return lines, nil
-}
-
-// docCommentAbove returns the contiguous //-style comment block that sits
-// directly above the 1-indexed declLine.
-func docCommentAbove(lines []string, declLine int) string {
-	// declLine is 1-indexed; the line above it is at slice index declLine-2.
-	var doc []string
-
-	for i := declLine - 2; i >= 0; i-- {
-		trimmed := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(trimmed, "//") {
-			doc = append(doc, trimmed)
-
-			continue
-		}
-
-		break
-	}
-
-	return strings.Join(doc, "\n")
-}
-
-// scanItemMethods returns the count of the item's CRUD client methods in the
-// file and the names of those whose preceding doc comment is marked preview.
-func scanItemMethods(lines []string, item string) (int, []string) {
-	var (
-		crud    int
-		preview []string
-	)
-
-	for i, line := range lines {
-		_, name := toolutil.ParseClientMethod(line)
-		if name == "" || !isItemCRUD(name, item) {
-			continue
-		}
-
-		crud++
-
-		// Line numbers passed to docCommentAbove are 1-indexed.
-		if containsMarker(docCommentAbove(lines, i+1)) {
-			preview = append(preview, name)
-		}
-	}
-
-	return crud, preview
-}
-
-// isItemCRUD reports whether method is a CRUD operation on the item itself,
-// e.g. GetNotebook, BeginCreateNotebook, ListNotebooks, UpdateNotebook.
-func isItemCRUD(method, item string) bool {
-	if !strings.Contains(strings.ToLower(method), strings.ToLower(item)) {
-		return false
-	}
-
-	for _, verb := range []string{"Get", "List", "Create", "Update", "Delete"} {
-		if strings.Contains(method, verb) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func containsMarker(doc string) bool {
@@ -783,26 +398,6 @@ func containsMarker(doc string) bool {
 
 	for _, marker := range previewMarkers {
 		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// loadServicePackages loads all packages under the services directory with full
-// type information.
-func pkgName(pkg *packages.Package) string {
-	if pkg.Name != "" {
-		return pkg.Name
-	}
-
-	return filepath.Base(pkg.PkgPath)
-}
-
-func hasName(names []*ast.Ident, target string) bool {
-	for _, n := range names {
-		if n.Name == target {
 			return true
 		}
 	}

--- a/tools/previewcheck/main_test.go
+++ b/tools/previewcheck/main_test.go
@@ -1,0 +1,365 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func Test_containsMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		doc  string
+		want bool
+	}{
+		{"currently in preview", "// This API is currently in preview.", true},
+		{"part of a preview release", "// GetFoo is part of a Preview release.", true},
+		{"mixed case marker", "// IS CURRENTLY IN PREVIEW", true},
+		{"marker mid-sentence", "// note: the endpoint is part of a preview release for now", true},
+		{"no marker", "// GetFoo retrieves a foo.", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := containsMarker(tt.doc); got != tt.want {
+				t.Errorf("containsMarker(%q) = %v, want %v", tt.doc, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_docCommentAbove(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		lines    []string
+		declLine int
+		want     string
+	}{
+		{
+			"contiguous doc block",
+			[]string{
+				"// GetFoo retrieves a foo.",
+				"// This API is currently in preview.",
+				"func (client *FooClient) GetFoo() {}",
+			},
+			3,
+			"// This API is currently in preview.\n// GetFoo retrieves a foo.",
+		},
+		{
+			"blank line breaks the block",
+			[]string{
+				"// GetFoo retrieves a foo.",
+				"",
+				"func (client *FooClient) GetFoo() {}",
+			},
+			3,
+			"",
+		},
+		{
+			"non-comment line breaks the block",
+			[]string{
+				"import \"context\"",
+				"func (client *FooClient) GetFoo() {}",
+			},
+			2,
+			"",
+		},
+		{
+			"declaration on first line does not panic",
+			[]string{"func (client *FooClient) GetFoo() {}"},
+			1,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := docCommentAbove(tt.lines, tt.declLine); got != tt.want {
+				t.Errorf("docCommentAbove(%d) = %q, want %q", tt.declLine, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isItemCRUD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		item   string
+		want   bool
+	}{
+		{"GetNotebook", "Notebook", true},
+		{"ListNotebooks", "Notebook", true},
+		{"BeginCreateNotebook", "Notebook", true},
+		{"UpdateNotebook", "Notebook", true},
+		{"DeleteNotebook", "Notebook", true},
+		// Item name matches but the verb is not a CRUD verb.
+		{"PublishNotebook", "Notebook", false},
+		// CRUD verb but the method is about a different entity.
+		{"GetWorkspace", "Notebook", false},
+		// Neither item nor CRUD verb.
+		{"ApplyTags", "Notebook", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+"/"+tt.item, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isItemCRUD(tt.method, tt.item); got != tt.want {
+				t.Errorf("isItemCRUD(%q, %q) = %v, want %v", tt.method, tt.item, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_scanItemMethods(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		"// GetNotebook gets a notebook.",
+		"// This API is currently in preview.",
+		"func (client *ItemsClient) GetNotebook(ctx context.Context) (Response, error) {",
+		"",
+		"// ListNotebooks lists notebooks.",
+		"func (client *ItemsClient) ListNotebooks(ctx context.Context) (Response, error) {",
+		"",
+		"// ApplyLabel applies a label (not the item).",
+		"func (client *ItemsClient) ApplyLabel(ctx context.Context) (Response, error) {",
+		"",
+		"// getInternal is unexported and must be ignored.",
+		"func (client *ItemsClient) getInternal() {}",
+	}
+
+	crud, preview := scanItemMethods(lines, "Notebook")
+
+	if crud != 2 {
+		t.Errorf("crud count = %d, want 2 (GetNotebook, ListNotebooks)", crud)
+	}
+
+	want := []string{"GetNotebook"}
+	if !slices.Equal(preview, want) {
+		t.Errorf("preview methods = %v, want %v", preview, want)
+	}
+}
+
+func Test_categorize(t *testing.T) {
+	t.Parallel()
+
+	results := []result{
+		{service: "no-decl", hasDeclaration: false},
+		{service: "undetermined", hasDeclaration: true, sdkCalls: 0},
+		{service: "under-marked", hasDeclaration: true, sdkCalls: 2, declared: false, previewAPIs: []string{"core.GetX"}},
+		{service: "review", hasDeclaration: true, sdkCalls: 2, declared: true, previewAPIs: nil},
+		{service: "correct-preview", hasDeclaration: true, sdkCalls: 2, declared: true, previewAPIs: []string{"core.GetX"}},
+		{service: "correct-ga", hasDeclaration: true, sdkCalls: 2, declared: false, previewAPIs: nil},
+	}
+
+	b := categorize(results, nil)
+
+	if len(b.undeclared) != 1 || b.undeclared[0].service != "no-decl" {
+		t.Errorf("undeclared = %+v, want [no-decl]", b.undeclared)
+	}
+
+	if b.undetermined != 1 {
+		t.Errorf("undetermined = %d, want 1", b.undetermined)
+	}
+
+	if len(b.underMarked) != 1 || b.underMarked[0].service != "under-marked" {
+		t.Errorf("underMarked = %+v, want [under-marked]", b.underMarked)
+	}
+
+	if len(b.review) != 1 || b.review[0].service != "review" {
+		t.Errorf("review = %+v, want [review]", b.review)
+	}
+
+	if len(b.excluded) != 0 || len(b.staleExcl) != 0 {
+		t.Errorf("excluded/stale should be empty without exclusions, got %+v / %+v", b.excluded, b.staleExcl)
+	}
+}
+
+func Test_categorize_exclusions(t *testing.T) {
+	t.Parallel()
+
+	results := []result{
+		{service: "under-marked", hasDeclaration: true, sdkCalls: 2, declared: false, previewAPIs: []string{"core.GetX"}},
+		{service: "review", hasDeclaration: true, sdkCalls: 2, declared: true, previewAPIs: nil},
+		{service: "correct-ga", hasDeclaration: true, sdkCalls: 2, declared: false, previewAPIs: nil},
+	}
+
+	exclusions := map[string]string{
+		"under-marked": "confirmed GA, stale SDK marker",
+		"correct-ga":   "stale exclusion, service is already consistent",
+	}
+
+	b := categorize(results, exclusions)
+
+	// under-marked is failing + excluded -> moves to excluded, not underMarked.
+	if len(b.underMarked) != 0 {
+		t.Errorf("underMarked = %+v, want empty (excluded)", b.underMarked)
+	}
+
+	if len(b.excluded) != 1 || b.excluded[0].res.service != "under-marked" {
+		t.Errorf("excluded = %+v, want [under-marked]", b.excluded)
+	}
+
+	if b.excluded[0].reason != "confirmed GA, stale SDK marker" {
+		t.Errorf("excluded reason = %q, want the configured reason", b.excluded[0].reason)
+	}
+
+	// review is not excluded -> still reported.
+	if len(b.review) != 1 || b.review[0].service != "review" {
+		t.Errorf("review = %+v, want [review]", b.review)
+	}
+
+	// correct-ga is consistent, so its exclusion is stale.
+	if !slices.Contains(b.staleExcl, "correct-ga") {
+		t.Errorf("staleExcl = %+v, want to contain correct-ga", b.staleExcl)
+	}
+}
+
+func Test_classify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		res  result
+		want category
+	}{
+		{"undeclared", result{hasDeclaration: false}, catUndeclared},
+		{"undetermined", result{hasDeclaration: true, sdkCalls: 0}, catUndetermined},
+		{"under-marked", result{hasDeclaration: true, sdkCalls: 1, declared: false, previewAPIs: []string{"core.X"}}, catUnderMarked},
+		{"review", result{hasDeclaration: true, sdkCalls: 1, declared: true}, catReview},
+		{"consistent-preview", result{hasDeclaration: true, sdkCalls: 1, declared: true, previewAPIs: []string{"core.X"}}, catConsistent},
+		{"consistent-ga", result{hasDeclaration: true, sdkCalls: 1, declared: false}, catConsistent},
+	}
+
+	for _, tt := range tests {
+		if got := classify(tt.res); got != tt.want {
+			t.Errorf("%s: classify = %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}
+
+func Test_loadExclusions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions:\n  - service: foo\n    reason: GA, stale marker\n")
+
+		m, err := loadExclusions(path)
+		if err != nil {
+			t.Fatalf("loadExclusions() error = %v", err)
+		}
+
+		if m["foo"] != "GA, stale marker" {
+			t.Errorf("m[foo] = %q, want the configured reason", m["foo"])
+		}
+	})
+
+	t.Run("missing service", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions:\n  - reason: no service\n")
+
+		_, err := loadExclusions(path)
+		if err == nil {
+			t.Error("loadExclusions() error = nil, want error for missing service")
+		}
+	})
+
+	t.Run("missing reason", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions:\n  - service: foo\n")
+
+		_, err := loadExclusions(path)
+		if err == nil {
+			t.Error("loadExclusions() error = nil, want error for missing reason")
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeExclusions(t, "exclusions: [::::\n")
+
+		_, err := loadExclusions(path)
+		if err == nil {
+			t.Error("loadExclusions() error = nil, want parse error")
+		}
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loadExclusions(filepath.Join(t.TempDir(), "nope.yaml"))
+		if err == nil {
+			t.Error("loadExclusions() error = nil, want read error")
+		}
+	})
+}
+
+func writeExclusions(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "exclusions.yaml")
+
+	err := os.WriteFile(path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	return path
+}
+
+func Test_result_expected_determinable(t *testing.T) {
+	t.Parallel()
+
+	if (result{}).expected() {
+		t.Error("empty result should not be expected preview")
+	}
+
+	if !(result{previewAPIs: []string{"core.GetX"}}).expected() {
+		t.Error("result with previewAPIs should be expected preview")
+	}
+
+	if (result{sdkCalls: 0}).determinable() {
+		t.Error("result with no SDK calls should not be determinable")
+	}
+
+	if !(result{sdkCalls: 1}).determinable() {
+		t.Error("result with SDK calls should be determinable")
+	}
+}
+
+func Test_fabricRoot(t *testing.T) {
+	t.Parallel()
+
+	coreFile := filepath.Join("home", "user", "sdk", "fabric", "core", "zz_generated_models.go")
+	want := filepath.Join("home", "user", "sdk", "fabric")
+
+	if got := fabricRoot(coreFile); got != want {
+		t.Errorf("fabricRoot(%q) = %q, want %q", coreFile, got, want)
+	}
+
+	notCore := filepath.Join("home", "user", "sdk", "fabric", "admin", "client.go")
+	if got := fabricRoot(notCore); got != "" {
+		t.Errorf("fabricRoot(%q) = %q, want empty (parent dir is not core)", notCore, got)
+	}
+}

--- a/tools/previewcheck/main_test.go
+++ b/tools/previewcheck/main_test.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -34,125 +32,6 @@ func Test_containsMarker(t *testing.T) {
 				t.Errorf("containsMarker(%q) = %v, want %v", tt.doc, got, tt.want)
 			}
 		})
-	}
-}
-
-func Test_docCommentAbove(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		lines    []string
-		declLine int
-		want     string
-	}{
-		{
-			"contiguous doc block",
-			[]string{
-				"// GetFoo retrieves a foo.",
-				"// This API is currently in preview.",
-				"func (client *FooClient) GetFoo() {}",
-			},
-			3,
-			"// This API is currently in preview.\n// GetFoo retrieves a foo.",
-		},
-		{
-			"blank line breaks the block",
-			[]string{
-				"// GetFoo retrieves a foo.",
-				"",
-				"func (client *FooClient) GetFoo() {}",
-			},
-			3,
-			"",
-		},
-		{
-			"non-comment line breaks the block",
-			[]string{
-				"import \"context\"",
-				"func (client *FooClient) GetFoo() {}",
-			},
-			2,
-			"",
-		},
-		{
-			"declaration on first line does not panic",
-			[]string{"func (client *FooClient) GetFoo() {}"},
-			1,
-			"",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := docCommentAbove(tt.lines, tt.declLine); got != tt.want {
-				t.Errorf("docCommentAbove(%d) = %q, want %q", tt.declLine, got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_isItemCRUD(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		method string
-		item   string
-		want   bool
-	}{
-		{"GetNotebook", "Notebook", true},
-		{"ListNotebooks", "Notebook", true},
-		{"BeginCreateNotebook", "Notebook", true},
-		{"UpdateNotebook", "Notebook", true},
-		{"DeleteNotebook", "Notebook", true},
-		// Item name matches but the verb is not a CRUD verb.
-		{"PublishNotebook", "Notebook", false},
-		// CRUD verb but the method is about a different entity.
-		{"GetWorkspace", "Notebook", false},
-		// Neither item nor CRUD verb.
-		{"ApplyTags", "Notebook", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.method+"/"+tt.item, func(t *testing.T) {
-			t.Parallel()
-
-			if got := isItemCRUD(tt.method, tt.item); got != tt.want {
-				t.Errorf("isItemCRUD(%q, %q) = %v, want %v", tt.method, tt.item, got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_scanItemMethods(t *testing.T) {
-	t.Parallel()
-
-	lines := []string{
-		"// GetNotebook gets a notebook.",
-		"// This API is currently in preview.",
-		"func (client *ItemsClient) GetNotebook(ctx context.Context) (Response, error) {",
-		"",
-		"// ListNotebooks lists notebooks.",
-		"func (client *ItemsClient) ListNotebooks(ctx context.Context) (Response, error) {",
-		"",
-		"// ApplyLabel applies a label (not the item).",
-		"func (client *ItemsClient) ApplyLabel(ctx context.Context) (Response, error) {",
-		"",
-		"// getInternal is unexported and must be ignored.",
-		"func (client *ItemsClient) getInternal() {}",
-	}
-
-	crud, preview := scanItemMethods(lines, "Notebook")
-
-	if crud != 2 {
-		t.Errorf("crud count = %d, want 2 (GetNotebook, ListNotebooks)", crud)
-	}
-
-	want := []string{"GetNotebook"}
-	if !slices.Equal(preview, want) {
-		t.Errorf("preview methods = %v, want %v", preview, want)
 	}
 }
 
@@ -254,80 +133,6 @@ func Test_classify(t *testing.T) {
 	}
 }
 
-func Test_loadExclusions(t *testing.T) {
-	t.Parallel()
-
-	t.Run("valid", func(t *testing.T) {
-		t.Parallel()
-
-		path := writeExclusions(t, "exclusions:\n  - service: foo\n    reason: GA, stale marker\n")
-
-		m, err := loadExclusions(path)
-		if err != nil {
-			t.Fatalf("loadExclusions() error = %v", err)
-		}
-
-		if m["foo"] != "GA, stale marker" {
-			t.Errorf("m[foo] = %q, want the configured reason", m["foo"])
-		}
-	})
-
-	t.Run("missing service", func(t *testing.T) {
-		t.Parallel()
-
-		path := writeExclusions(t, "exclusions:\n  - reason: no service\n")
-
-		_, err := loadExclusions(path)
-		if err == nil {
-			t.Error("loadExclusions() error = nil, want error for missing service")
-		}
-	})
-
-	t.Run("missing reason", func(t *testing.T) {
-		t.Parallel()
-
-		path := writeExclusions(t, "exclusions:\n  - service: foo\n")
-
-		_, err := loadExclusions(path)
-		if err == nil {
-			t.Error("loadExclusions() error = nil, want error for missing reason")
-		}
-	})
-
-	t.Run("malformed yaml", func(t *testing.T) {
-		t.Parallel()
-
-		path := writeExclusions(t, "exclusions: [::::\n")
-
-		_, err := loadExclusions(path)
-		if err == nil {
-			t.Error("loadExclusions() error = nil, want parse error")
-		}
-	})
-
-	t.Run("nonexistent path", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := loadExclusions(filepath.Join(t.TempDir(), "nope.yaml"))
-		if err == nil {
-			t.Error("loadExclusions() error = nil, want read error")
-		}
-	})
-}
-
-func writeExclusions(t *testing.T, content string) string {
-	t.Helper()
-
-	path := filepath.Join(t.TempDir(), "exclusions.yaml")
-
-	err := os.WriteFile(path, []byte(content), 0o600)
-	if err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	return path
-}
-
 func Test_result_expected_determinable(t *testing.T) {
 	t.Parallel()
 
@@ -345,21 +150,5 @@ func Test_result_expected_determinable(t *testing.T) {
 
 	if !(result{sdkCalls: 1}).determinable() {
 		t.Error("result with SDK calls should be determinable")
-	}
-}
-
-func Test_fabricRoot(t *testing.T) {
-	t.Parallel()
-
-	coreFile := filepath.Join("home", "user", "sdk", "fabric", "core", "zz_generated_models.go")
-	want := filepath.Join("home", "user", "sdk", "fabric")
-
-	if got := fabricRoot(coreFile); got != want {
-		t.Errorf("fabricRoot(%q) = %q, want %q", coreFile, got, want)
-	}
-
-	notCore := filepath.Join("home", "user", "sdk", "fabric", "admin", "client.go")
-	if got := fabricRoot(notCore); got != "" {
-		t.Errorf("fabricRoot(%q) = %q, want empty (parent dir is not core)", notCore, got)
 	}
 }

--- a/tools/spncheck/README.md
+++ b/tools/spncheck/README.md
@@ -1,0 +1,98 @@
+# spncheck
+
+`spncheck` verifies that every Terraform resource/data source is correctly
+marked as **supporting service principal (SPN) authentication vs. not**. It
+cross-checks each service package's declared support (`IsSPNSupported` in
+`base.go`'s `ItemTypeInfo`) against the actual service-principal support of the
+[`fabric-sdk-go`](https://github.com/microsoft/fabric-sdk-go) APIs the package
+calls.
+
+It shares its scanning engine with [`previewcheck`](../previewcheck/): both tools
+resolve SDK call sites, read SDK doc comments, and compare the result against a
+declared `ItemTypeInfo` flag via the common
+[`tools/internal/toolutil`](../internal/toolutil/) package. Only the marker they
+look for (and the declared field they compare) differ.
+
+## How it works
+
+A package should be `IsSPNSupported = true` only when **every** SDK client
+function it invokes supports service principal. Each SDK client function
+documents its supported identities in a table under this heading in the doc
+comment directly above the function:
+
+```text
+MICROSOFT ENTRA SUPPORTED IDENTITIES
+| Identity | Support | |-|-| | User | Yes | | Service principal ... | Yes |
+```
+
+The **Service principal** row's Support cell is one of:
+
+- `Yes` — the API supports service principal
+- `No` — the API does **not** support service principal
+- a conditional sentence — supported only under stated conditions
+
+`spncheck` resolves each SDK call site to the exact SDK function (using the Go
+type checker, so import aliases and receivers resolve correctly), reads its
+identity table, and flags the package when **any** called API has a hard `No`.
+
+## Run it
+
+```sh
+go run ./tools/spncheck                  # report findings, exit 1 if any
+go run ./tools/spncheck -dir DIR         # scan a different services directory
+go run ./tools/spncheck -exclusions PATH # use a specific exclusions file
+```
+
+Exit codes: `0` = all consistent, `1` = mismatch (or stale exclusion) found,
+`2` = error.
+
+## Reading the output
+
+Findings are split by confidence, because the SDK's identity tables are not
+always present (a missing table does **not** prove an API supports SPN):
+
+- **OVER-MARKED** (high confidence) — declared `IsSPNSupported = true`, but a
+  called SDK API is documented as **not** supporting service principal. The item
+  **should** be `false`. Fix these.
+- **REVIEW** (low confidence) — declared `IsSPNSupported = false`, but every
+  called API supports service principal. *Possibly* promotable to `true`, but
+  confirm manually.
+- **EXCLUDED** — a failing item suppressed via `exclusions.yaml` (see below).
+- **STALE EXCLUSIONS** — an excluded item that is no longer a mismatch; remove
+  the entry. Stale entries also fail the run (exit `1`).
+- **UNDETERMINED** — no `fabric-sdk-go` calls found (e.g. generic `fabricitem`
+  resources whose CRUD runs through the shared abstraction). Informational.
+
+## Acting on a failure
+
+- **OVER-MARKED** → set `IsSPNSupported = false` on the item's `ItemTypeInfo` in
+  its `base.go`, **or** — if the item genuinely supports SPN and the SDK
+  annotation is stale/conservative — exclude it (see below).
+- **REVIEW** → manually verify against Fabric docs; flip `IsSPNSupported` to
+  `true` only if every operation truly supports service principal.
+
+If an item calls an SDK package whose directory can't be derived from the item
+name automatically, add a mapping to `sdkPackageOverrides` in
+[`main.go`](./main.go).
+
+## Excluding items with stale SDK annotations
+
+The SDK sometimes annotates an API more conservatively than reality. That makes
+an item show up as **OVER-MARKED** even though keeping it `true` is correct. List
+such items in [`exclusions.yaml`](./exclusions.yaml) with a reason:
+
+```yaml
+exclusions:
+  - service: someitem
+    reason: SPN-supported; someclient.DoThing carries a stale SDK identity annotation
+```
+
+`service` is the service package name (the value shown in the report). An
+excluded item moves to the **EXCLUDED** section instead of failing the run.
+Exclusion is deliberately narrow — a stale entry (the item is no longer a
+mismatch, e.g. the SDK corrected the annotation) is reported as **STALE** so it
+can be removed. Note that a service-level exclusion also suppresses *future*
+genuine non-SPN APIs that item may start calling, so keep the list minimal and
+reasoned.
+
+The tool's unit tests run via `task test:gaptools`.

--- a/tools/spncheck/exclusions.yaml
+++ b/tools/spncheck/exclusions.yaml
@@ -1,0 +1,9 @@
+# Exclusions for spncheck — service packages whose service-principal support
+# should NOT be flagged, typically items whose called fabric-sdk-go APIs carry a
+# stale or overly conservative identity annotation in their doc comments.
+#
+# Format: service (the service package name) + reason.
+# When the SDK later corrects the annotation (so the service is no longer a
+# mismatch), spncheck reports the entry as STALE so it can be removed.
+
+exclusions: []

--- a/tools/spncheck/main.go
+++ b/tools/spncheck/main.go
@@ -1,0 +1,456 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Command spncheck audits every Terraform resource/data source service package
+// and verifies that its declared service-principal support (the IsSPNSupported
+// field in base.go's ItemTypeInfo) matches the actual service-principal support
+// of the Microsoft Fabric Go SDK APIs that the package calls.
+//
+// An item supports service principal (IsSPNSupported = true) only when ALL of
+// the fabric-sdk-go client functions it invokes support service principal. Each
+// SDK client function documents its supported identities in a table under the
+// following heading in the doc comment directly above the function:
+//
+//	MICROSOFT ENTRA SUPPORTED IDENTITIES
+//	| Identity | Support | |-|-| | User | Yes | | Service principal ... | Yes |
+//
+// The "Service principal" row's Support cell is one of:
+//
+//	Yes  -> the API supports service principal
+//	No   -> the API does NOT support service principal
+//	<conditional sentence> -> supported only under certain conditions
+//
+// spncheck flags an item when ANY called SDK API has a hard "No" in its Service
+// principal cell: that item cannot fully support service principal. Because the
+// SDK's identity tables are not always present, findings are split by confidence:
+//
+//   - OVER-MARKED (high confidence): declared IsSPNSupported = true but a called
+//     API is documented as NOT supporting service principal. Should be false.
+//   - REVIEW (low confidence): declared IsSPNSupported = false but every called
+//     API supports service principal. Possibly promotable to true, but requires
+//     manual confirmation because SDK annotations are incomplete.
+//   - UNDETERMINED: no fabric-sdk-go calls found in the package (e.g. generic
+//     fabricitem resources whose CRUD runs through the shared abstraction).
+//
+// Usage:
+//
+//	go run ./tools/spncheck                  # report findings, exit 1 if any
+//	go run ./tools/spncheck -dir DIR         # scan a different services directory
+//	go run ./tools/spncheck -exclusions PATH # use a specific exclusions file
+//
+// An item whose called SDK API carries a stale or overly conservative identity
+// annotation can be suppressed by listing its service package in exclusions.yaml
+// (see that file).
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/microsoft/terraform-provider-fabric/tools/internal/toolutil"
+)
+
+// spnSupport is the parsed service-principal support state of a single SDK API,
+// derived from the "Service principal" row of its MICROSOFT ENTRA SUPPORTED
+// IDENTITIES table.
+type spnSupport int
+
+const (
+	spnUnknown     spnSupport = iota // no identity table (or unparsable)
+	spnYes                           // "| Yes |"
+	spnNo                            // "| No |"
+	spnConditional                   // supported only under stated conditions
+)
+
+// sdkPackageOverrides maps a FabricItemType item name to its dedicated
+// fabric-sdk-go package directory when the default lowercase derivation does not
+// match. Add entries here for any item whose SDK package cannot be resolved
+// automatically.
+var sdkPackageOverrides = map[string]string{ //nolint:gochecknoglobals
+	"Map": "maps",
+}
+
+// exit codes.
+const (
+	exitOK       = 0
+	exitMismatch = 1
+	exitError    = 2
+)
+
+// CLI flags.
+var (
+	dirFlag        = flag.String("dir", toolutil.DefaultServicesDir, "services directory to scan (relative to the module root)") //nolint:gochecknoglobals
+	exclusionsFlag = flag.String("exclusions", "", "path to exclusions YAML file (default: auto-detected)")                      //nolint:gochecknoglobals
+)
+
+func main() {
+	flag.Parse()
+
+	os.Exit(run())
+}
+
+func run() int {
+	root, err := toolutil.ModuleRoot()
+	if err != nil {
+		toolutil.Errf("error: %v\n", err)
+
+		return exitError
+	}
+
+	pkgs, err := toolutil.LoadServicePackages(root, *dirFlag)
+	if err != nil {
+		toolutil.Errf("error loading packages: %v\n", err)
+
+		return exitError
+	}
+
+	exclusionsPath := *exclusionsFlag
+	if exclusionsPath == "" {
+		exclusionsPath = filepath.Join(root, "tools", "spncheck", "exclusions.yaml")
+	}
+
+	exclusions, err := toolutil.LoadExclusions(exclusionsPath)
+	if err != nil {
+		toolutil.Errf("error loading exclusions: %v\n", err)
+
+		return exitError
+	}
+
+	dc := toolutil.NewDocCache()
+
+	results := make([]result, 0, len(pkgs))
+
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			for _, e := range pkg.Errors {
+				toolutil.Errf("package %s: %v\n", pkg.PkgPath, e)
+			}
+
+			return exitError
+		}
+
+		res, ok := analyzePackage(pkg, dc)
+		if !ok {
+			continue
+		}
+
+		results = append(results, res)
+	}
+
+	slices.SortFunc(results, func(a, b result) int { return strings.Compare(a.service, b.service) })
+
+	return report(results, exclusions)
+}
+
+// result captures the analysis outcome for a single service package.
+type result struct {
+	service        string   // package name (e.g. "lakehouse")
+	declared       bool     // current IsSPNSupported value
+	hasDeclaration bool     // ItemTypeInfo.IsSPNSupported was found
+	sdkCalls       int      // number of distinct SDK funcs called
+	nonSPNAPIs     []string // SDK funcs documented as NOT supporting SPN (pkg.Func)
+}
+
+// expected returns the IsSPNSupported value implied by the SDK usage: an item
+// supports service principal only when none of its called APIs is a hard "No".
+func (r result) expected() bool { return len(r.nonSPNAPIs) == 0 }
+
+// determinable is true when at least one SDK API call was found, so the
+// expected status can be trusted.
+func (r result) determinable() bool { return r.sdkCalls > 0 }
+
+func report(results []result, exclusions map[string]string) int {
+	b := categorize(results, exclusions)
+
+	for _, r := range b.undeclared {
+		toolutil.Outf("%-40s no ItemTypeInfo.IsSPNSupported field found\n", r.service)
+	}
+
+	printOverMarked(b.overMarked)
+
+	printReview(b.review)
+
+	printExcluded(b.excluded)
+
+	printStaleExclusions(b.staleExcl)
+
+	toolutil.Outf("\nScanned %d services: %d over-marked, %d to review, %d undeclared, %d excluded, %d stale, %d undetermined\n",
+		len(results), len(b.overMarked), len(b.review), len(b.undeclared), len(b.excluded), len(b.staleExcl), b.undetermined)
+
+	if len(b.overMarked) > 0 || len(b.review) > 0 || len(b.undeclared) > 0 || len(b.staleExcl) > 0 {
+		return exitMismatch
+	}
+
+	return exitOK
+}
+
+// category is the service-principal-support classification of a single service.
+type category int
+
+const (
+	catConsistent   category = iota // declared status matches SDK usage
+	catUndetermined                 // no SDK calls, status not determinable
+	catOverMarked                   // declared SPN-supported but a called API is not
+	catReview                       // declared unsupported but every called API supports SPN
+	catUndeclared                   // no ItemTypeInfo.IsSPNSupported field found
+)
+
+// classify returns the service-principal-support category for a single result.
+func classify(r result) category {
+	if !r.hasDeclaration {
+		return catUndeclared
+	}
+
+	if !r.determinable() {
+		return catUndetermined
+	}
+
+	switch {
+	case r.declared && !r.expected():
+		return catOverMarked
+	case !r.declared && r.expected():
+		return catReview
+	default:
+		return catConsistent
+	}
+}
+
+// excludedResult is a failing service suppressed by the exclusions file.
+type excludedResult struct {
+	res    result
+	reason string
+}
+
+// buckets groups categorized services by confidence level.
+type buckets struct {
+	overMarked   []result         // declared SPN-supported but a called API is not
+	review       []result         // declared unsupported but every called API supports SPN
+	undeclared   []result         // no ItemTypeInfo.IsSPNSupported field found
+	excluded     []excludedResult // failing but suppressed via exclusions.yaml
+	staleExcl    []string         // excluded services that no longer mismatch
+	undetermined int              // no SDK calls, status not determinable
+}
+
+// categorize splits services into over-marked, review, undeclared, excluded,
+// and undetermined groups, routing failing services listed in exclusions into
+// the excluded bucket and flagging exclusions that no longer apply as stale.
+func categorize(results []result, exclusions map[string]string) buckets {
+	var b buckets
+
+	used := make(map[string]struct{})
+
+	for _, r := range results {
+		switch cat := classify(r); cat {
+		case catUndetermined:
+			b.undetermined++
+		case catConsistent:
+			// declared status is correct; nothing to report.
+		default:
+			b.addFailing(r, cat, exclusions, used)
+		}
+	}
+
+	for svc := range exclusions {
+		if _, ok := used[svc]; !ok {
+			b.staleExcl = append(b.staleExcl, svc)
+		}
+	}
+
+	slices.Sort(b.staleExcl)
+
+	return b
+}
+
+// addFailing routes a failing result into the excluded bucket (if its service
+// is listed in exclusions) or its failing-category bucket.
+func (b *buckets) addFailing(r result, cat category, exclusions map[string]string, used map[string]struct{}) {
+	if reason, ok := exclusions[r.service]; ok {
+		b.excluded = append(b.excluded, excludedResult{res: r, reason: reason})
+		used[r.service] = struct{}{}
+
+		return
+	}
+
+	switch cat {
+	case catOverMarked:
+		b.overMarked = append(b.overMarked, r)
+	case catReview:
+		b.review = append(b.review, r)
+	case catUndeclared:
+		b.undeclared = append(b.undeclared, r)
+	default:
+	}
+}
+
+func printOverMarked(overMarked []result) {
+	if len(overMarked) == 0 {
+		return
+	}
+
+	toolutil.Outf("\nOVER-MARKED — declared SPN-supported but the SDK marks a called API as NOT supporting service principal (should be IsSPNSupported = false):\n")
+
+	for _, r := range overMarked {
+		toolutil.Outf("  ✗ %-38s\n", r.service)
+		printNonSPNAPIs(r)
+	}
+}
+
+func printReview(review []result) {
+	if len(review) == 0 {
+		return
+	}
+
+	toolutil.Outf("\nREVIEW — declared NOT SPN-supported but every called API supports service principal (possibly IsSPNSupported = true, confirm manually):\n")
+
+	for _, r := range review {
+		toolutil.Outf("  ? %-38s\n", r.service)
+	}
+}
+
+func printExcluded(excluded []excludedResult) {
+	if len(excluded) == 0 {
+		return
+	}
+
+	toolutil.Outf("\nEXCLUDED — suppressed via exclusions.yaml (confirmed intentional):\n")
+
+	for _, e := range excluded {
+		toolutil.Outf("  - %-38s %s\n", e.res.service, e.reason)
+	}
+}
+
+func printStaleExclusions(stale []string) {
+	if len(stale) == 0 {
+		return
+	}
+
+	toolutil.Outf("\nSTALE EXCLUSIONS — no longer mismatched, remove from exclusions.yaml:\n")
+
+	for _, svc := range stale {
+		toolutil.Outf("  %s\n", svc)
+	}
+}
+
+func printNonSPNAPIs(r result) {
+	if len(r.nonSPNAPIs) == 0 {
+		return
+	}
+
+	for _, api := range r.nonSPNAPIs {
+		toolutil.Outf("    non-SPN API: %s\n", api)
+	}
+}
+
+// analyzePackage inspects a service package: it locates ItemTypeInfo.IsSPNSupported
+// and collects every fabric-sdk-go function it calls, flagging those that do not
+// support service principal.
+func analyzePackage(pkg *packages.Package, dc *toolutil.DocCache) (result, bool) {
+	res := result{service: toolutil.PkgName(pkg)}
+
+	if v, ok := toolutil.ExtractItemTypeInfoBool(pkg, "IsSPNSupported"); ok {
+		res.hasDeclaration = true
+		res.declared = v
+	}
+
+	nonSPNSet := map[string]struct{}{}
+
+	for _, call := range toolutil.CollectSDKCalls(pkg) {
+		res.sdkCalls++
+
+		if parseSPNSupport(dc.DocCommentAt(call.Pos)) == spnNo {
+			nonSPNSet[call.ID] = struct{}{}
+		}
+	}
+
+	// Fallback: generic fabricitem resources make no direct SDK calls in-package.
+	// Resolve their FabricItemType to the dedicated SDK package and scan its
+	// exported client methods for service-principal support.
+	if res.sdkCalls == 0 {
+		determineViaItemType(pkg, dc, &res, nonSPNSet)
+	}
+
+	res.nonSPNAPIs = toolutil.SortedKeys(nonSPNSet)
+
+	// Skip packages that have neither a declaration nor any relevance.
+	if !res.hasDeclaration && res.sdkCalls == 0 {
+		return res, false
+	}
+
+	return res, true
+}
+
+// determineViaItemType resolves the FabricItemType constant to its dedicated
+// fabric-sdk-go package and scans that package's exported client methods for
+// service-principal support, closing the gap for generic fabricitem resources.
+func determineViaItemType(pkg *packages.Package, dc *toolutil.DocCache, res *result, nonSPNSet map[string]struct{}) {
+	pkgDir, item, ok := toolutil.SDKPackageDir(pkg, sdkPackageOverrides)
+	if !ok {
+		return
+	}
+
+	methods := dc.ScanItemCRUD(pkgDir, item)
+	if len(methods) == 0 {
+		return
+	}
+
+	res.sdkCalls += len(methods)
+
+	for _, m := range methods {
+		if parseSPNSupport(m.Doc) == spnNo {
+			nonSPNSet[strings.ToLower(item)+"."+m.Name] = struct{}{}
+		}
+	}
+}
+
+// parseSPNSupport reads the "Service principal" row of the MICROSOFT ENTRA
+// SUPPORTED IDENTITIES table in doc and returns its support state. It normalizes
+// the doc by stripping all whitespace (the table wraps across comment lines) and
+// inspecting the support cell that immediately follows the "service principal"
+// identity label.
+func parseSPNSupport(doc string) spnSupport {
+	// Collapse all whitespace so the wrapped, multi-line table becomes a single
+	// contiguous string that is trivial to slice on the "|" cell delimiters.
+	norm := strings.Join(strings.Fields(strings.ToLower(doc)), "")
+
+	if !strings.Contains(norm, "microsoftentrasupportedidentities") {
+		return spnUnknown
+	}
+
+	// Use LastIndex: "service principal" can appear in free-text (e.g.
+	// PERMISSIONS lines) before the table. The last occurrence is always the
+	// one inside the actual identity table row.
+	idx := strings.LastIndex(norm, "serviceprincipal")
+	if idx < 0 {
+		return spnUnknown
+	}
+
+	// The support cell is the first "| value |" after the (bracketed) identity
+	// label. Identity labels and URL references never contain "|".
+	rest := norm[idx:]
+
+	_, after, ok := strings.Cut(rest, "|")
+	if !ok {
+		return spnUnknown
+	}
+
+	cell := after
+
+	before0, _, ok0 := strings.Cut(cell, "|")
+	if !ok0 {
+		return spnUnknown
+	}
+
+	switch before0 {
+	case "yes":
+		return spnYes
+	case "no":
+		return spnNo
+	default:
+		return spnConditional
+	}
+}

--- a/tools/spncheck/main_test.go
+++ b/tools/spncheck/main_test.go
@@ -1,0 +1,192 @@
+// Copyright Microsoft Corporation 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func Test_parseSPNSupport(t *testing.T) {
+	t.Parallel()
+
+	const heading = "// MICROSOFT ENTRA SUPPORTED IDENTITIES This API supports the Microsoft identities listed in this section.\n"
+
+	tests := []struct {
+		name string
+		doc  string
+		want spnSupport
+	}{
+		{
+			"service principal yes",
+			heading + "// | Identity | Support | |-|-| | User | Yes | | Service principal [/entra/foo] and Managed identities [/entra/bar] | Yes |",
+			spnYes,
+		},
+		{
+			"service principal no",
+			heading + "// | Identity | Support | |-|-| | User | Yes | | Service principal [/entra/foo] | No |",
+			spnNo,
+		},
+		{
+			"conditional support",
+			heading + "// | Identity | Support | |-|-| | User | Yes | | Service principal [/entra/foo] and Managed identities [/entra/bar] | When the item type in the call is supported. |",
+			spnConditional,
+		},
+		{
+			"table wrapped across comment lines",
+			heading +
+				"// | Identity | Support | |-|-| | User | Yes | | Service principal [/entra/foo]\n" +
+				"// and Managed identities\n" +
+				"// [/entra/bar] | No |",
+			spnNo,
+		},
+		{
+			"no identity table",
+			"// GetFoo retrieves a foo. It does not document identities.",
+			spnUnknown,
+		},
+		{
+			"heading present but no service principal row",
+			heading + "// | Identity | Support | |-|-| | User | Yes |",
+			spnUnknown,
+		},
+		{
+			"service principal in free text before table",
+			"// PERMISSIONS The caller must authenticate using a service principal.\n" +
+				heading +
+				"// | Identity | Support | |-|-| | User | Yes | | Service principal [/entra/foo] | Yes |",
+			spnYes,
+		},
+		{
+			"empty",
+			"",
+			spnUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseSPNSupport(tt.doc); got != tt.want {
+				t.Errorf("parseSPNSupport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_categorize(t *testing.T) {
+	t.Parallel()
+
+	results := []result{
+		{service: "no-decl", hasDeclaration: false},
+		{service: "undetermined", hasDeclaration: true, sdkCalls: 0},
+		{service: "over-marked", hasDeclaration: true, sdkCalls: 2, declared: true, nonSPNAPIs: []string{"core.GetX"}},
+		{service: "review", hasDeclaration: true, sdkCalls: 2, declared: false, nonSPNAPIs: nil},
+		{service: "correct-supported", hasDeclaration: true, sdkCalls: 2, declared: true, nonSPNAPIs: nil},
+		{service: "correct-unsupported", hasDeclaration: true, sdkCalls: 2, declared: false, nonSPNAPIs: []string{"core.GetX"}},
+	}
+
+	b := categorize(results, nil)
+
+	if len(b.undeclared) != 1 || b.undeclared[0].service != "no-decl" {
+		t.Errorf("undeclared = %+v, want [no-decl]", b.undeclared)
+	}
+
+	if b.undetermined != 1 {
+		t.Errorf("undetermined = %d, want 1", b.undetermined)
+	}
+
+	if len(b.overMarked) != 1 || b.overMarked[0].service != "over-marked" {
+		t.Errorf("overMarked = %+v, want [over-marked]", b.overMarked)
+	}
+
+	if len(b.review) != 1 || b.review[0].service != "review" {
+		t.Errorf("review = %+v, want [review]", b.review)
+	}
+
+	if len(b.excluded) != 0 || len(b.staleExcl) != 0 {
+		t.Errorf("excluded/stale should be empty without exclusions, got %+v / %+v", b.excluded, b.staleExcl)
+	}
+}
+
+func Test_categorize_exclusions(t *testing.T) {
+	t.Parallel()
+
+	results := []result{
+		{service: "over-marked", hasDeclaration: true, sdkCalls: 2, declared: true, nonSPNAPIs: []string{"core.GetX"}},
+		{service: "review", hasDeclaration: true, sdkCalls: 2, declared: false, nonSPNAPIs: nil},
+		{service: "correct-supported", hasDeclaration: true, sdkCalls: 2, declared: true, nonSPNAPIs: nil},
+	}
+
+	exclusions := map[string]string{
+		"over-marked":       "SPN-supported, stale SDK annotation",
+		"correct-supported": "stale exclusion, service is already consistent",
+	}
+
+	b := categorize(results, exclusions)
+
+	if len(b.overMarked) != 0 {
+		t.Errorf("overMarked = %+v, want empty (excluded)", b.overMarked)
+	}
+
+	if len(b.excluded) != 1 || b.excluded[0].res.service != "over-marked" {
+		t.Errorf("excluded = %+v, want [over-marked]", b.excluded)
+	}
+
+	if b.excluded[0].reason != "SPN-supported, stale SDK annotation" {
+		t.Errorf("excluded reason = %q, want the configured reason", b.excluded[0].reason)
+	}
+
+	if len(b.review) != 1 || b.review[0].service != "review" {
+		t.Errorf("review = %+v, want [review]", b.review)
+	}
+
+	if !slices.Contains(b.staleExcl, "correct-supported") {
+		t.Errorf("staleExcl = %+v, want to contain correct-supported", b.staleExcl)
+	}
+}
+
+func Test_classify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		res  result
+		want category
+	}{
+		{"undeclared", result{hasDeclaration: false}, catUndeclared},
+		{"undetermined", result{hasDeclaration: true, sdkCalls: 0}, catUndetermined},
+		{"over-marked", result{hasDeclaration: true, sdkCalls: 1, declared: true, nonSPNAPIs: []string{"core.X"}}, catOverMarked},
+		{"review", result{hasDeclaration: true, sdkCalls: 1, declared: false}, catReview},
+		{"consistent-supported", result{hasDeclaration: true, sdkCalls: 1, declared: true}, catConsistent},
+		{"consistent-unsupported", result{hasDeclaration: true, sdkCalls: 1, declared: false, nonSPNAPIs: []string{"core.X"}}, catConsistent},
+	}
+
+	for _, tt := range tests {
+		if got := classify(tt.res); got != tt.want {
+			t.Errorf("%s: classify = %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}
+
+func Test_result_expected_determinable(t *testing.T) {
+	t.Parallel()
+
+	if !(result{}).expected() {
+		t.Error("result with no non-SPN APIs should be expected SPN-supported")
+	}
+
+	if (result{nonSPNAPIs: []string{"core.GetX"}}).expected() {
+		t.Error("result with a non-SPN API should not be expected SPN-supported")
+	}
+
+	if (result{sdkCalls: 0}).determinable() {
+		t.Error("result with no SDK calls should not be determinable")
+	}
+
+	if !(result{sdkCalls: 1}).determinable() {
+		t.Error("result with SDK calls should be determinable")
+	}
+}


### PR DESCRIPTION

❓ What are you trying to address

The provider needs to stay in sync with  fabric-sdk-go , but there's currently no automated way to (a) spot SDK control-plane capabilities that have no Terraform resource yet, or (b) catch resources whose  IsPreview  flag disagrees with the SDK's documented preview status. Both are easy to miss in review and drift over time.

✨ Description of new changes

Adds two developer audit tools plus shared tooling:

•  tools/gapcheck  — scans the SDK's client methods and the provider's service packages, then reports every SDK method with no corresponding Terraform coverage and no exclusion. Coverage of already-implemented methods is auto-detected from provider source; intentional non-resources are pruned via  exclusions.yaml .

•  tools/previewcheck  — cross-checks each service's declared  IsPreview  against the preview status of the SDK APIs it calls (resolved via the Go type checker). Splits findings by confidence (UNDER-MARKED vs. REVIEW).
•  tools/internal/toolutil  — shared helpers (module-root resolution, package loading, client-method parsing) used by both tools.
•  Taskfile.yml  — new  check:gaps ,  check:preview , and  test:gaptools  tasks.
•  go.mod  — promotes  golang.org/x/tools  to a direct dependency (now imported by  toolutil ).

Both tools follow the standard checker exit-code convention:  0  = clean,  1  = findings (gaps/mismatches/stale exclusions),  2  = internal error. Each ships with a README and unit tests.
