### PR TITLE
ci(deps): bump go version from 1.26.3 to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/terraform-provider-fabric
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/tools/itemgen/go.mod
+++ b/tools/itemgen/go.mod
@@ -1,3 +1,3 @@
 module github.com/microsoft/terraform-provider-fabric/tools/itemgen
 
-go 1.26.2
+go 1.26.4


### PR DESCRIPTION
 task install:goreleaser  was failing because goreleaser v2.17.0 requires Go ≥ 1.26.4, while  go.mod  pinned 1.26.3:

github.com/goreleaser/goreleaser/v2@v2.17.0 requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)

Change

• Bumped  go  directive in  go.mod  from  1.26.3  →  1.26.4 .