### PR TITLE
build(deps): bump github.com/microsoft/fabric-sdk-go from 0.18.0 to 0.19.0 in the all group

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
       "configureZshAsDefaultShell": true
     },
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.26.1"
+      "version": "1.26.5"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.13",

--- a/docs/data-sources/gateway.md
+++ b/docs/data-sources/gateway.md
@@ -50,7 +50,7 @@ data "fabric_gateway" "example_by_name" {
 - `load_balancing_setting` (String) The load balancing setting. Value must be one of : `DistributeEvenly`, `Failover`.
 - `number_of_member_gateways` (Number) The number of member gateways. Value must be between 1 and 9.
 - `public_key` (Attributes) The public key of the primary gateway member. Used to encrypt the credentials for creating and updating connections. (see [below for nested schema](#nestedatt--public_key))
-- `type` (String) The Gateway type. Value must be one of : `OnPremises`, `OnPremisesPersonal`, `VirtualNetwork`.
+- `type` (String) The Gateway type. Value must be one of : `OnPremises`, `OnPremisesPersonal`, `StreamingVirtualNetwork`, `VirtualNetwork`.
 - `version` (String) The Gateway version.
 - `virtual_network_azure_resource` (Attributes) The Azure virtual network resource. (see [below for nested schema](#nestedatt--virtual_network_azure_resource))
 

--- a/docs/data-sources/gateways.md
+++ b/docs/data-sources/gateways.md
@@ -53,7 +53,7 @@ Read-Only:
 - `load_balancing_setting` (String) The load balancing setting. Value must be one of : `DistributeEvenly`, `Failover`.
 - `number_of_member_gateways` (Number) The number of member gateways. Value must be between 1 and 9.
 - `public_key` (Attributes) The public key of the primary gateway member. Used to encrypt the credentials for creating and updating connections. (see [below for nested schema](#nestedatt--values--public_key))
-- `type` (String) The Gateway type. Value must be one of : `OnPremises`, `OnPremisesPersonal`, `VirtualNetwork`.
+- `type` (String) The Gateway type. Value must be one of : `OnPremises`, `OnPremisesPersonal`, `StreamingVirtualNetwork`, `VirtualNetwork`.
 - `version` (String) The Gateway version.
 - `virtual_network_azure_resource` (Attributes) The Azure virtual network resource. (see [below for nested schema](#nestedatt--values--virtual_network_azure_resource))
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/microsoft/fabric-sdk-go v0.18.0
+	github.com/microsoft/fabric-sdk-go v0.19.0
 	github.com/ohler55/ojg v1.28.3
 	github.com/orange-cloudavenue/terraform-plugin-framework-superschema v1.12.0
 	github.com/orange-cloudavenue/terraform-plugin-framework-supertypes v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/microsoft/fabric-sdk-go v0.18.0 h1:VbFvJE1oVDI32ijvBSNlH3GnRjdlaLQo7aAGzm4yDbs=
-github.com/microsoft/fabric-sdk-go v0.18.0/go.mod h1:j3pU5WFYM/t4ijryCB4wxH0YLddmtNqjwtiJKaxvBOk=
+github.com/microsoft/fabric-sdk-go v0.19.0 h1:XpRRQmfii/ZyvS+ZotzJ+y6VoV5cJrmVm0shHgmq/TM=
+github.com/microsoft/fabric-sdk-go v0.19.0/go.mod h1:ZAzHIIKjsyNA6SZ1F1GIZybottJaaoZWuZmJq2RfVr4=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=

--- a/internal/services/gateway/schema.go
+++ b/internal/services/gateway/schema.go
@@ -36,7 +36,10 @@ func itemSchema(isList bool) superschema.Schema { //revive:disable-line:flag-par
 		}
 	}
 
-	possibleGatewayTypeValues := utils.RemoveSlicesByValues(fabcore.PossibleGatewayTypeValues(), []fabcore.GatewayType{fabcore.GatewayTypeOnPremises, fabcore.GatewayTypeOnPremisesPersonal})
+	possibleGatewayTypeValues := utils.RemoveSlicesByValues(
+		fabcore.PossibleGatewayTypeValues(),
+		[]fabcore.GatewayType{fabcore.GatewayTypeOnPremises, fabcore.GatewayTypeOnPremisesPersonal, fabcore.GatewayTypeStreamingVirtualNetwork},
+	)
 
 	return superschema.Schema{
 		Resource: superschema.SchemaDetails{


### PR DESCRIPTION
Bumps the all group with 1 update in the / directory: [github.com/microsoft/fabric-sdk-go](https://github.com/microsoft/fabric-sdk-go).

Updates `github.com/microsoft/fabric-sdk-go` from 0.18.0 to 0.19.0

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/microsoft/fabric-sdk-go/releases">github.com/microsoft/fabric-sdk-go's releases</a>.</em></p>
<blockquote>
<h2>v0.19.0</h2>
<h2>What's Changed</h2>
<ul>
<li>ci(deps): bump actions/checkout from 6.0.2 to 6.0.3 in /.github/workflows in the all group in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/127">microsoft/fabric-sdk-go#127</a></li>
<li>ci(deps): bump the all group across 1 directory with 2 updates in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/130">microsoft/fabric-sdk-go#130</a></li>
<li>ci(deps): bump the all group across 1 directory with 2 updates in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/132">microsoft/fabric-sdk-go#132</a></li>
<li>ci(deps): bump the all group across 1 directory with 2 updates in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/136">microsoft/fabric-sdk-go#136</a></li>
<li>build(deps): bump the all group with 2 updates in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/138">microsoft/fabric-sdk-go#138</a></li>
<li>build(deps): bump the all group with 4 updates in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/139">microsoft/fabric-sdk-go#139</a></li>
<li>chore(release): v0.19.0 in <a href="https://redirect.github.com/microsoft/fabric-sdk-go/pull/140">microsoft/fabric-sdk-go#140</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/microsoft/fabric-sdk-go/compare/v0.18.0...v0.19.0">https://github.com/microsoft/fabric-sdk-go/compare/v0.18.0...v0.19.0</a></p>
</blockquote>
</details>

---

Updates `github.com/microsoft/fabric-sdk-go` from 0.18.0 to 0.19.0.

- Release notes: https://github.com/microsoft/fabric-sdk-go/releases/tag/v0.19.0
- Compare view: https://github.com/microsoft/fabric-sdk-go/compare/v0.18.0...v0.19.0

The provider builds and `go vet ./...` passes cleanly with no source changes required; only `go.mod` and `go.sum` are updated.
