### PR TITLE
fix(changelog): add missing changelog for wspl

### DIFF
--- a/.changes/unreleased/fixed-20260804-143115.yaml
+++ b/.changes/unreleased/fixed-20260804-143115.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fixed an issue that prevented networking communication policy APIs from being called when workspace private links were enabled.
+time: 2026-08-04T14:31:15.352006357Z
+custom:
+    Issue: "1031"


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Adds the missing changelog entry for the workspace private links fix tracked in #1031.

## ✨ Description of new changes

Adds an unreleased `fixed` changelog fragment documenting that networking communication policy APIs can now be called when workspace private links are enabled.

## ☑️ PR Checklist

- [x] Link to the issue you are addressing is included above
- [x] Ensure the PR description clearly describes the feature you're adding and any known limitations

## ☑️ Resources / Data Sources Checklist

Not applicable; this PR only adds a changelog fragment.