### PR TITLE
build(deps): bump github.com/microsoft/fabric-sdk-go from 0.19.0 to 0…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/microsoft/fabric-sdk-go v0.19.0
+	github.com/microsoft/fabric-sdk-go v0.20.0
 	github.com/ohler55/ojg v1.28.4
 	github.com/orange-cloudavenue/terraform-plugin-framework-superschema v1.12.0
 	github.com/orange-cloudavenue/terraform-plugin-framework-supertypes v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/microsoft/fabric-sdk-go v0.19.0 h1:XpRRQmfii/ZyvS+ZotzJ+y6VoV5cJrmVm0shHgmq/TM=
-github.com/microsoft/fabric-sdk-go v0.19.0/go.mod h1:ZAzHIIKjsyNA6SZ1F1GIZybottJaaoZWuZmJq2RfVr4=
+github.com/microsoft/fabric-sdk-go v0.20.0 h1:mjsu0c10YCoYlG8eCyPIjLJsHhrwGXMLh5Dsqa30Ufc=
+github.com/microsoft/fabric-sdk-go v0.20.0/go.mod h1:hM6mZCAkFicenuV87Qy+qj1kmB4FHpQae/71VyvdJns=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=


### PR DESCRIPTION
Bumps the all group with 1 update in the / directory: [github.com/microsoft/fabric-sdk-go](https://github.com/microsoft/fabric-sdk-go).

Updates github.com/microsoft/fabric-sdk-go from 0.19,0 to 0.20.0